### PR TITLE
Update things related to registers

### DIFF
--- a/src/frontend/containers.rs
+++ b/src/frontend/containers.rs
@@ -398,28 +398,28 @@ impl<'a, T: 'a + Source> From<&'a mut T> for RadecoModule<'a, DefaultFnTy> {
             let handle = thread::Builder::new().name(f.name.as_ref().unwrap().to_owned()).spawn(move || {
                 let mut rfn = ssa_single_fn(&f, &reg_info, instructions, offset);
                 // Attach additional information as necessay from `FunctionInfo`.
-                {
-                    // Add all defined registers to bindings.
-                    let regs = {
-                        let ssa = rfn.ssa_mut();
-                        let start = ssa.entry_node().expect("Incomplete CFG graph");
-                        let rs = ssa.registers_in(start).expect("No registers state node found");
-                        ssa.operands_of(rs)
-                    };
-                    for (i, reg) in regs.iter().enumerate() {
-                        let mut bind = Binding::default();
-                        bind.mark_register(rfn.ssa
-                            .regnames
-                            .get(i)
-                            .cloned()
-                            .unwrap_or_else(String::new));
-                        bind.add_refs(vec![*reg]);
-                        // Set the initial bind as register name, which may be
-                        // changed after analyzed.
-                        bind.set_name(rfn.ssa.regnames.get(i).cloned().unwrap_or_else(String::new));
-                        rfn.bindings.insert(bind);
-                    }
-                }
+                // {
+                //     // Add all defined registers to bindings.
+                //     let regs = {
+                //         let ssa = rfn.ssa_mut();
+                //         let start = ssa.entry_node().expect("Incomplete CFG graph");
+                //         let rs = ssa.registers_in(start).expect("No registers state node found");
+                //         ssa.operands_of(rs)
+                //     };
+                //     for (i, reg) in regs.iter().enumerate() {
+                //         let mut bind = Binding::default();
+                //         bind.mark_register(rfn.ssa
+                //             .regnames
+                //             .get(i)
+                //             .cloned()
+                //             .unwrap_or_else(String::new));
+                //         bind.add_refs(vec![*reg]);
+                //         // Set the initial bind as register name, which may be
+                //         // changed after analyzed.
+                //         bind.set_name(rfn.ssa.regnames.get(i).cloned().unwrap_or_else(String::new));
+                //         rfn.bindings.insert(bind);
+                //     }
+                // }
                 rfn.offset = offset;
                 fix_call_info(&mut rfn);
                 load_datarefs(&mut rfn, f.datarefs);

--- a/src/frontend/radeco_containers.rs
+++ b/src/frontend/radeco_containers.rs
@@ -651,7 +651,7 @@ impl<'a> ModuleLoader<'a> {
                             })
                             .unwrap_or(&NodeIndex::end());
                     }
-                    vb.ridx = sub_reg_f.register_id_by_alias(alias);
+                    vb.ridx = sub_reg_f.register_id_by_alias(alias).map(|rid| rid.to_u8() as u64);
                     Some(vb)
                 } else {
                     None

--- a/src/middle/ir_reader/lowering.rs
+++ b/src/middle/ir_reader/lowering.rs
@@ -9,9 +9,9 @@ use middle::ssa::ssa_traits::{SSAMod, ValueInfo, SSA};
 use middle::ssa::ssastorage::SSAStorage;
 
 use std::collections::HashMap;
-use std::fmt::Write;
 use std::error;
 use std::fmt;
+use std::fmt::Write;
 
 pub type Result<T> = ::std::result::Result<T, LoweringError>;
 
@@ -70,7 +70,6 @@ impl<'a> LowerSsa<'a> {
     }
 
     fn lower_function(mut self, sfn: sast::Function) -> Result<()> {
-
         self.lower_entry_reg_state(sfn.entry_reg_state)?;
 
         let mut first = true;
@@ -223,7 +222,9 @@ impl<'a> LowerSsa<'a> {
                     if let Some(addr) = opt_addr {
                         write!(comment, "@{}", addr).unwrap();
                     }
-                    let val = self.ssa.insert_comment(lower_valueinfo(sret.value.1), comment)?;
+                    let val = self
+                        .ssa
+                        .insert_comment(lower_valueinfo(sret.value.1), comment)?;
                     self.ssa.op_use(val, regid.to_u8(), res);
                     self.values.insert(sret.value.0, val);
                 }
@@ -259,18 +260,14 @@ impl<'a> LowerSsa<'a> {
 
     fn index_of_reg(&self, sreg: &sast::PhysReg) -> Result<RegisterId> {
         if sreg.0 == "mem" {
-            Ok(RegisterId::from_usize(
-                self.ssa.regfile.whole_names.len(),
-            ))
+            Ok(self.ssa.regfile.mem_id())
         } else {
-            if let Some(x) = self.ssa.regfile.register_id_by_name(&sreg.0) {
-                Ok(RegisterId::from_usize(x as usize))
-            } else {
-                Err(LoweringError::InvalidAst(format!(
-                    "no physical register: {}",
-                    sreg.0
-                )))
-            }
+            self.ssa
+                .regfile
+                .register_id_by_name(&sreg.0)
+                .ok_or_else(|| {
+                    LoweringError::InvalidAst(format!("no physical register: {}", sreg.0))
+                })
         }
     }
 }

--- a/src/middle/ir_reader/lowering.rs
+++ b/src/middle/ir_reader/lowering.rs
@@ -88,9 +88,6 @@ impl<'a> LowerSsa<'a> {
 
         self.lower_final_reg_state(sfn.final_reg_state)?;
 
-        let regs = self.ssa.regfile.whole_names.clone();
-        self.ssa.map_registers(regs);
-
         Ok(())
     }
 

--- a/src/middle/ir_reader/mod.rs
+++ b/src/middle/ir_reader/mod.rs
@@ -149,7 +149,7 @@ define-fun main(unknown) -> unknown {
         let frs_node = ssa.registers_in(exit).unwrap();
         let frs = utils::register_state_info(frs_node, &ssa);
 
-        let rax_i = ssa.regfile.register_id_by_name("rax").unwrap() as usize;
+        let rax_i = ssa.regfile.register_id_by_name("rax").unwrap().to_usize();
         let v1 = frs[RegisterId::from_usize(rax_i)].0;
         assert!(exprs.contains(&v1));
         assert_eq!(
@@ -171,7 +171,7 @@ define-fun main(unknown) -> unknown {
                 "rdi".to_owned()
             )
         );
-        let rdi_i = ssa.regfile.register_id_by_name("rdi").unwrap() as usize;
+        let rdi_i = ssa.regfile.register_id_by_name("rdi").unwrap().to_usize();
         assert_eq!(cmt_rdi, ers[RegisterId::from_usize(rdi_i)].0);
     }
 

--- a/src/middle/phiplacement.rs
+++ b/src/middle/phiplacement.rs
@@ -1005,9 +1005,6 @@ impl<'a, T> PhiPlacer<'a, T>
             }
         }
 
-        // TODO: remove
-        self.ssa.map_registers(self.regfile.whole_names.clone());
-
         // Associate basic block with correct block sizes.
         for opn in ops.windows(2) {
             let op1 = &opn[0];

--- a/src/middle/regfile/mod.rs
+++ b/src/middle/regfile/mod.rs
@@ -10,8 +10,10 @@
 //! Also contains [`RegisterUsage`], and [`RegisterMap`].
 
 mod regmap;
+mod regusage;
 
 pub use self::regmap::RegisterMap;
+pub use self::regusage::RegisterUsage;
 
 use middle::ir;
 
@@ -154,12 +156,12 @@ impl SubRegisterFile {
     }
 
     // Get id for a register named `reg`
-    pub fn register_id_by_name(&self, reg: &str) -> Option<u64> {
-        self.named_registers.get(reg).map(|sr| sr.base)
+    pub fn register_id_by_name(&self, reg: &str) -> Option<RegisterId> {
+        self.named_registers.get(reg).map(|sr| RegisterId::from_usize(sr.base as usize))
     }
 
     // Get id for register by alias/role
-    pub fn register_id_by_alias(&self, alias: &str) -> Option<u64> {
+    pub fn register_id_by_alias(&self, alias: &str) -> Option<RegisterId> {
         if let Some(rname) = self.alias_info.get(alias) {
             self.register_id_by_name(rname)
         } else {
@@ -218,14 +220,18 @@ impl SubRegisterFile {
         )))
     }
 
+    pub fn iter_register_ids(&self) -> impl Iterator<Item = RegisterId> {
+        (0..=self.whole_registers.len()).map(RegisterId::from_usize)
+    }
+
+    pub fn mem_id(&self) -> RegisterId {
+        RegisterId::from_usize(self.whole_registers.len())
+    }
+
     /// Creates a new mutable `RegisterUsage`.
     /// The returned value says "reads and clobbers everything".
     pub fn new_register_usage(&self) -> RegisterUsage {
-        let reg_count = self.whole_registers.len() + 1;
-        RegisterUsage {
-            ignores: FixedBitSet::with_capacity(reg_count),
-            preserves: FixedBitSet::with_capacity(reg_count),
-        }
+        RegisterUsage::with_register_count(self.whole_registers.len() + 1)
     }
 
     /// Converts the given `LCCInfo` imported from r2 to a `RegisterUsage`.
@@ -236,28 +242,25 @@ impl SubRegisterFile {
         callconv: &LCCInfo,
         callconv_name: &str,
     ) -> Option<RegisterUsage> {
-        let reg_count = self.whole_registers.len() + 1;
+        let mut ret = self.new_register_usage();
 
-        let mut ignores = FixedBitSet::with_capacity(reg_count);
-        ignores.set_range(.., true);
+        ret.set_all_ignored();
         for regname in callconv.args.as_ref()? {
             // bail if we don't recognize the register name
             let reg_id = self.register_id_by_name(regname)?;
-            ignores.set(reg_id as usize, false);
+            ret.set_read(reg_id);
         }
         // memory is always read
-        ignores.set(reg_count - 1, false);
-
-        let mut preserves = FixedBitSet::with_capacity(reg_count);
+        ret.set_read(self.mem_id());
 
         for regname in callconv_name_to_preserved_list(callconv_name) {
             let reg_id = self
                 .register_id_by_name(regname)
                 .expect("unknown register in internal preserved list");
-            preserves.set(reg_id as usize, true)
+            ret.set_preserved(reg_id);
         }
 
-        Some(RegisterUsage { ignores, preserves })
+        Some(ret)
     }
 
     /// Creates an empty `RegisterMap`.
@@ -279,80 +282,6 @@ impl RegisterId {
     pub fn from_usize(i: usize) -> Self {
         assert!(i <= u8::max_value() as usize);
         RegisterId(i as u8)
-    }
-}
-
-use fixedbitset::FixedBitSet;
-
-/// The set of registers (possibly including the memory "register") that a
-/// function reads and/or preserves.
-///
-/// **Note:** Instances created with [`Default::default`] *cannot be modified*
-/// To create a mutable instance, use [`SubRegisterFile::new_register_usage`].
-///
-/// **Implementation note:** This stores which registers a function *ignores*
-/// instead of what it reads. This is so the `Default` implementation of
-/// "reads and clobbers everything" is safe to assign to unanalyzed functions.
-#[derive(Debug, Clone, Default)]
-pub struct RegisterUsage {
-    /// Registers that are *not* parameters
-    ignores: FixedBitSet,
-    /// Callee-saved registers
-    preserves: FixedBitSet,
-}
-
-impl RegisterUsage {
-    /// Returns `true` if a callee that adheres to `self` can be called by a
-    /// caller that assumes that callee adheres to `other`.
-    pub fn is_compatible_with(&self, other: &RegisterUsage) -> bool {
-        // self.reads.is_subset(&other.reads) && self.preserves.is_superset(&other.preserves)
-        other.ignores.ones().all(|i| self.ignores[i])
-            && other.preserves.ones().all(|i| self.preserves[i])
-    }
-
-    /// Returns if this `RegisterUsage` can be modified.
-    /// If this returns `false`, *calling the `set_*` functions will panic*.
-    pub fn is_mutable(&self) -> bool {
-        self.ignores.len() > 0 && self.preserves.len() > 0
-    }
-
-    pub fn is_ignored(&self, reg_id: RegisterId) -> bool {
-        self.ignores[reg_id.to_usize()]
-    }
-    pub fn is_read(&self, reg_id: RegisterId) -> bool {
-        !self.ignores[reg_id.to_usize()]
-    }
-    pub fn is_preserved(&self, reg_id: RegisterId) -> bool {
-        self.preserves[reg_id.to_usize()]
-    }
-    pub fn is_clobbered(&self, reg_id: RegisterId) -> bool {
-        !self.preserves[reg_id.to_usize()]
-    }
-
-    pub fn set_ignored(&mut self, reg_id: RegisterId) -> () {
-        self.ignores.set(reg_id.to_usize(), true)
-    }
-    pub fn set_read(&mut self, reg_id: RegisterId) -> () {
-        self.ignores.set(reg_id.to_usize(), false)
-    }
-    pub fn set_preserved(&mut self, reg_id: RegisterId) -> () {
-        self.preserves.set(reg_id.to_usize(), true)
-    }
-    pub fn set_clobbered(&mut self, reg_id: RegisterId) -> () {
-        self.preserves.set(reg_id.to_usize(), false)
-    }
-
-    pub fn set_all_ignored(&mut self) -> () {
-        self.ignores.set_range(.., true)
-    }
-    pub fn set_all_read(&mut self) -> () {
-        self.ignores.set_range(.., false)
-    }
-    pub fn set_all_preserved(&mut self) -> () {
-        self.preserves.set_range(.., true)
-    }
-    pub fn set_all_clobbered(&mut self) -> () {
-        self.preserves.set_range(.., false)
     }
 }
 

--- a/src/middle/regfile/regusage.rs
+++ b/src/middle/regfile/regusage.rs
@@ -1,0 +1,81 @@
+use super::RegisterId;
+use fixedbitset::FixedBitSet;
+
+/// The set of registers (possibly including the memory "register") that a
+/// function reads and/or preserves.
+///
+/// **Note:** Instances created with [`Default::default`] *cannot be modified*
+/// To create a mutable instance, use [`SubRegisterFile::new_register_usage`].
+///
+/// **Implementation note:** This stores which registers a function *ignores*
+/// instead of what it reads. This is so the `Default` implementation of
+/// "reads and clobbers everything" is safe to assign to unanalyzed functions.
+#[derive(Debug, Clone, Default)]
+pub struct RegisterUsage {
+    /// Registers that are *not* parameters
+    ignores: FixedBitSet,
+    /// Callee-saved registers
+    preserves: FixedBitSet,
+}
+
+impl RegisterUsage {
+    pub(super) fn with_register_count(regcount: usize) -> Self {
+        RegisterUsage {
+            ignores: FixedBitSet::with_capacity(regcount),
+            preserves: FixedBitSet::with_capacity(regcount),
+        }
+    }
+
+    /// Returns `true` if a callee that adheres to `self` can be called by a
+    /// caller that assumes that callee adheres to `other`.
+    pub fn is_compatible_with(&self, other: &RegisterUsage) -> bool {
+        // self.reads.is_subset(&other.reads) && self.preserves.is_superset(&other.preserves)
+        other.ignores.ones().all(|i| self.ignores[i])
+            && other.preserves.ones().all(|i| self.preserves[i])
+    }
+
+    /// Returns if this `RegisterUsage` can be modified.
+    /// If this returns `false`, *calling the `set_*` functions will panic*.
+    pub fn is_mutable(&self) -> bool {
+        self.ignores.len() > 0 && self.preserves.len() > 0
+    }
+
+    pub fn is_ignored(&self, reg_id: RegisterId) -> bool {
+        self.ignores[reg_id.to_usize()]
+    }
+    pub fn is_read(&self, reg_id: RegisterId) -> bool {
+        !self.ignores[reg_id.to_usize()]
+    }
+    pub fn is_preserved(&self, reg_id: RegisterId) -> bool {
+        self.preserves[reg_id.to_usize()]
+    }
+    pub fn is_clobbered(&self, reg_id: RegisterId) -> bool {
+        !self.preserves[reg_id.to_usize()]
+    }
+
+    pub fn set_ignored(&mut self, reg_id: RegisterId) -> () {
+        self.ignores.set(reg_id.to_usize(), true)
+    }
+    pub fn set_read(&mut self, reg_id: RegisterId) -> () {
+        self.ignores.set(reg_id.to_usize(), false)
+    }
+    pub fn set_preserved(&mut self, reg_id: RegisterId) -> () {
+        self.preserves.set(reg_id.to_usize(), true)
+    }
+    pub fn set_clobbered(&mut self, reg_id: RegisterId) -> () {
+        self.preserves.set(reg_id.to_usize(), false)
+    }
+
+    pub fn set_all_ignored(&mut self) -> () {
+        self.ignores.set_range(.., true)
+    }
+    pub fn set_all_read(&mut self) -> () {
+        self.ignores.set_range(.., false)
+    }
+    pub fn set_all_preserved(&mut self) -> () {
+        self.preserves.set_range(.., true)
+    }
+    pub fn set_all_clobbered(&mut self) -> () {
+        self.preserves.set_range(.., false)
+    }
+}

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -315,9 +315,6 @@ pub trait SSAMod: SSA + CFGMod {
 
     /// Remove control flow edge. This is a part of SSAMod as this potentially modifies the ssa.
     fn remove_data_edge(&mut self, i: Self::CFEdgeRef);
-
-    /// Map register names into SSA Graph
-    fn map_registers(&mut self, regs: Vec<String>);
 }
 
 /// Extras. TODO

--- a/src/middle/ssa/ssastorage.rs
+++ b/src/middle/ssa/ssastorage.rs
@@ -169,8 +169,6 @@ pub struct SSAStorage {
     entry_node: NodeIndex,
     exit_node: NodeIndex,
     pub assoc_data: AssociatedData,
-    #[deprecated(note = "use regfile instead")]
-    pub regnames: Vec<String>,
     pub regfile: Arc<SubRegisterFile>,
     pub constants: HashMap<u64, NodeIndex>,
 }
@@ -182,7 +180,6 @@ impl default::Default for SSAStorage {
             entry_node: NodeIndex::end(),
             exit_node: NodeIndex::end(),
             assoc_data: HashMap::new(),
-            regnames: Vec::new(),
             regfile: Arc::default(),
             constants: HashMap::new(),
         }
@@ -196,7 +193,6 @@ impl SSAStorage {
             entry_node: NodeIndex::end(),
             exit_node: NodeIndex::end(),
             assoc_data: HashMap::new(),
-            regnames: Vec::new(),
             regfile: Arc::default(),
             constants: HashMap::new(),
         }
@@ -1063,10 +1059,6 @@ impl SSAMod for SSAStorage {
         }
 
         self.g.remove_edge(i);
-    }
-
-    fn map_registers(&mut self, regs: Vec<String>) {
-        self.regnames = regs;
     }
 }
 


### PR DESCRIPTION
- `phiplacement` uses `SubRegisterFile` internals directly, which still uses numbers.
- `SSA::registers` and `SSAMod::set_register` still use strings