### PR TITLE
Fix `nearest_common_dominator` test

### DIFF
--- a/src/backend/ctrl_flow_struct/graph_utils/test.rs
+++ b/src/backend/ctrl_flow_struct/graph_utils/test.rs
@@ -86,7 +86,7 @@ fn qc_nearest_common_dominator(
     if in_node_is.is_empty() {
         return TestResult::discard();
     }
-    let root = if let Some(root) = mk_rooted_stable_graph(&mut graph, root_i, false) {
+    let root = if let Some(root) = mk_rooted_stable_graph(&mut graph, root_i, true) {
         root
     } else {
         return TestResult::discard();


### PR DESCRIPTION
The algorithm only works with acyclic graphs but we've been testing with potentially cyclic graphs.