### PR TITLE
Improve backend::lang_c::c_cfg_builder

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,2 @@
 format_strings = true
 reorder_imports = true
-take_source_hints = false

--- a/src/backend/lang_c/c_cfg_builder.rs
+++ b/src/backend/lang_c/c_cfg_builder.rs
@@ -483,6 +483,50 @@ impl<'a> CCFGDataMap<'a> {
         }
     }
 
+    fn op_to_expr(op: &MOpcode) -> Option<c_ast::Expr> {
+        match op {
+            MOpcode::OpAdd => c_ast::Expr::Add,
+            MOpcode::OpAnd => c_ast::Expr::And,
+            MOpcode::OpDiv => c_ast::Expr::Div,
+            MOpcode::OpEq => c_ast::Expr::Eq,
+            MOpcode::OpGt => c_ast::Expr::Gt,
+            MOpcode::OpLsl => c_ast::Expr::Shl,
+            MOpcode::OpLsr => c_ast::Expr::Shr,
+            MOpcode::OpLt => c_ast::Expr::Lt,
+            MOpcode::OpMod => c_ast::Expr::Mod,
+            MOpcode::OpMul => c_ast::Expr::Mul,
+            MOpcode::OpNot => c_ast::Expr::Not,
+            MOpcode::OpOr => c_ast::Expr::Or,
+            MOpcode::OpRol => unimplemented!(),
+            MOpcode::OpRor => unimplemented!(),
+            MOpcode::OpSub => c_ast::Expr::Sub,
+            MOpcode::OpXor => c_ast::Expr::Xor,
+            // TODO Add `Narrow` info
+            MOpcode::OpNarrow(size) => c_ast::Expr::Cast(size as usize),
+            // TODO Add `SignExt`
+            MOpcode::OpSignExt(size) => c_ast::Expr::Cast(size as usize),
+            // TODO Add `ZeroExt`
+            MOpcode::OpZeroExt(size) => c_ast::Expr::Cast(size as usize),
+            _ => None,
+        }
+    }
+
+    fn def_of(&self, node: SSARef) -> (c_ast::Expr, Vec<SSARef>) {
+        let op = self.ssa.opcode(node).unwrap_or(MOpcode::OpInvalid);
+        match (&op, op_to_expr(&op)) {
+            (MOpcode::OpStore, None) => unimplemented!(),
+            (MOpcode::OpLoad, None) => unimplemented!(),
+            (MOpcode::OpNarrow(size), exp)
+            | (MOpcode::OpSignExt(size), exp)
+            | (MOpcode::OpZeroExt(size), exp) => unimplemented!(),
+            (_, exp) if op.is_ternary() => unimplemented!(),
+            (_, exp) if op.is_binary() => unimplemented!(),
+            (_, exp) if op.is_unary() => unimplemented!(),
+            (MOpcode::OpCall, None) => unimplemented!(),
+            _ => unimplemented!(),
+        }
+    }
+
     fn update_values(&mut self, ret_node: SSARef, ast: &mut CCFG) {
         debug_assert!(self.ssa.is_expr(ret_node));
         radeco_trace!("CCFGBuilder::update_values {:?}", ret_node);

--- a/src/backend/lang_c/c_cfg_builder.rs
+++ b/src/backend/lang_c/c_cfg_builder.rs
@@ -719,25 +719,7 @@ impl CCFGDataMapVerifier {
     }
 
     fn verify_ops(ast: &mut CCFG, datamap: &mut CCFGDataMap) -> Result<(), String> {
-        Self::verify_handler_each_node(
-            ast,
-            datamap,
-            &Self::verify_handle_uniop,
-            "Handle unary operator",
-        )?;
-
-        Self::verify_handler_each_node(
-            ast,
-            datamap,
-            &Self::verify_handle_binop,
-            "Handle binary operator",
-        )?;
-        Self::verify_handler_each_node(
-            ast,
-            datamap,
-            &Self::verify_handle_cast,
-            "Handle casting operator",
-        )?;
+        Self::verify_handler_each_node(ast, datamap, &Self::verify_handle, "Handle operator")?;
         Ok(())
     }
 
@@ -866,32 +848,7 @@ impl CCFGDataMapVerifier {
         }
     }
 
-    fn verify_handle_uniop(
-        node: SSARef,
-        ast: &mut CCFG,
-        datamap: &mut CCFGDataMap,
-    ) -> Result<(), String> {
-        // Ensure `handle_uniop` insert node as key into var_map.
-        let expr = c_ast::Expr::Not;
-        let operand_node = datamap
-            .var_map
-            .iter()
-            .map(|(n, _)| *n)
-            .filter(|n| *n != node)
-            .next()
-            .unwrap();
-        // Erase the key so as to ensure whether the key will be correctly inserted
-        // by handle_uniop
-        datamap.var_map.remove(&node);
-        datamap.handle_uniop(node, operand_node, expr, ast);
-        if datamap.var_map.get(&node).is_none() {
-            Err(format!("Failed to handle unary operator: {:?}", node))
-        } else {
-            Ok(())
-        }
-    }
-
-    fn verify_handle_binop(
+    fn verify_handle(
         node: SSARef,
         ast: &mut CCFG,
         datamap: &mut CCFGDataMap,
@@ -908,35 +865,9 @@ impl CCFGDataMapVerifier {
         // Erase the key so as to ensure whether the key will be correctly inserted
         // by handle_binop
         datamap.var_map.remove(&node);
-        datamap.handle_binop(node, operand_nodes, expr, ast);
+        datamap.handle(node, operand_nodes, expr, ast);
         if datamap.var_map.get(&node).is_none() {
             Err(format!("Failed to handle binary operator: {:?}", node))
-        } else {
-            Ok(())
-        }
-    }
-
-    fn verify_handle_cast(
-        node: SSARef,
-        ast: &mut CCFG,
-        datamap: &mut CCFGDataMap,
-    ) -> Result<(), String> {
-        // Ensure `handle_cast` insert node as key into var_map.
-        let expr = c_ast::Expr::Cast(8);
-        let operand_node = datamap
-            .var_map
-            .iter()
-            .map(|(n, _)| *n)
-            .filter(|n| *n != node)
-            .next()
-            .unwrap()
-            .clone();
-        // Erase the key so as to ensure whether the key will be correctly inserted
-        // by handle_uniop
-        datamap.var_map.remove(&node);
-        datamap.handle_cast(node, operand_node, expr, ast);
-        if datamap.var_map.get(&node).is_none() {
-            Err(format!("Failed to handle cast operator: {:?}", node))
         } else {
             Ok(())
         }

--- a/src/backend/lang_c/c_cfg_builder.rs
+++ b/src/backend/lang_c/c_cfg_builder.rs
@@ -662,7 +662,6 @@ impl<'a> CCFGDataMap<'a> {
 
 struct CCFGBuilderVerifier {}
 
-// type Verifier = Fn(SSARef, &mut CCFG, &mut CCFGDataMap) -> Result<(), String>;
 impl CCFGBuilderVerifier {
     const DELIM: &'static str = "; ";
 
@@ -799,7 +798,7 @@ impl CCFGDataMapVerifier {
                 let ret = if let Some(s) = strings.get(&tmp_val) {
                     format!("\"{}\"", s)
                 } else {
-                    tmp_val.to_string()
+                    format!("0x{:x}", tmp_val)
                 };
                 Some(ret)
             } else {
@@ -920,7 +919,7 @@ impl CCFGDataMapVerifier {
             .take(2)
             .collect();
         // Erase the key so as to ensure whether the key will be correctly inserted
-        // by handle_binop
+        // by handle
         datamap.var_map.remove(&node);
         datamap.handle(node, operand_nodes, expr, cfg);
         if datamap.var_map.get(&node).is_none() {

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -9,7 +9,7 @@
 //!
 //! These traits extend upon the ones provided in `cfg_traits`
 //!
-//! # Design 
+//! # Design
 //!  * `SSA` - Analogous to `CFG` this trait provides __accessors__ to
 //!  the data: Methods to enumerate operations, discovered connected operations,
 //!  determine which operation a basic block is in. etc.
@@ -21,11 +21,11 @@
 //! The associated type `SSA::ValueRef` is used by the methods to refer to
 //! nodes.
 
-use std::hash::Hash;
 use std::fmt::{self, Debug};
+use std::hash::Hash;
 
+use super::cfg_traits::{CFGMod, CFG};
 use middle::ir;
-use super::cfg_traits::{CFG, CFGMod};
 
 #[macro_export]
 macro_rules! entry_node_err {
@@ -34,7 +34,7 @@ macro_rules! entry_node_err {
             radeco_err!("Incomplete CFG graph");
             $ssa.invalid_action().unwrap()
         })
-    }
+    };
 }
 
 #[macro_export]
@@ -44,20 +44,20 @@ macro_rules! exit_node_err {
             radeco_err!("Incomplete CFG graph");
             $ssa.invalid_action().unwrap()
         })
-    }
+    };
 }
 
 #[macro_export]
 macro_rules! registers_in_err {
     ($ssa:expr, $node:expr) => {
-            registers_in_err!($ssa, $node, $ssa.invalid_value().unwrap())
+        registers_in_err!($ssa, $node, $ssa.invalid_value().unwrap())
     };
     ($ssa:expr, $node:expr, $default:expr) => {
         $ssa.registers_in($node).unwrap_or_else(|| {
             radeco_err!("No register state node found");
             $default
         })
-    }
+    };
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -85,17 +85,26 @@ pub struct ValueInfo {
 
 macro_rules! scalar {
     ($w:expr) => {
-        ValueInfo::new($crate::middle::ssa::ssa_traits::ValueType::Scalar, ir::WidthSpec::new_known($w))
-    }
+        ValueInfo::new(
+            $crate::middle::ssa::ssa_traits::ValueType::Scalar,
+            ir::WidthSpec::new_known($w),
+        )
+    };
 }
 
 macro_rules! reference {
     () => {
-        ValueInfo::new($crate::middle::ssa::ssa_traits::ValueType::Reference, ir::WidthSpec::Unknown)
+        ValueInfo::new(
+            $crate::middle::ssa::ssa_traits::ValueType::Reference,
+            ir::WidthSpec::Unknown,
+        )
     };
     ($w:expr) => {
-        ValueInfo::new($crate::middle::ssa::ssa_traits::ValueType::Reference, ir::WidthSpec::new_known($w))
-    }
+        ValueInfo::new(
+            $crate::middle::ssa::ssa_traits::ValueType::Reference,
+            ir::WidthSpec::new_known($w),
+        )
+    };
 }
 
 impl ValueInfo {
@@ -267,7 +276,6 @@ pub trait SSA: CFG {
 
 /// Trait for modifying SSA data
 pub trait SSAMod: SSA + CFGMod {
-
     /// Set the address of a value
     fn set_address(&mut self, i: Self::ValueRef, addr: ir::MAddress);
 
@@ -278,7 +286,12 @@ pub trait SSAMod: SSA + CFGMod {
     fn set_selector(&mut self, node: Self::ValueRef, block: Self::ActionRef);
 
     /// Insert a new operation node.
-    fn insert_op(&mut self, opc: ir::MOpcode, vt: ValueInfo, addr: Option<u64>) -> Option<Self::ValueRef>;
+    fn insert_op(
+        &mut self,
+        opc: ir::MOpcode,
+        vt: ValueInfo,
+        addr: Option<u64>,
+    ) -> Option<Self::ValueRef>;
 
     /// Add a new constant node.
     fn insert_const(&mut self, value: u64) -> Option<Self::ValueRef>;
@@ -291,7 +304,7 @@ pub trait SSAMod: SSA + CFGMod {
 
     /// Add a new comment node
     fn insert_comment(&mut self, vt: ValueInfo, msg: String) -> Option<Self::ValueRef>;
-    
+
     /// Associate a node with index n with a block
     fn insert_into_block(&mut self, node: Self::ValueRef, block: Self::ActionRef, ir::MAddress);
 
@@ -325,11 +338,11 @@ pub trait SSAMod: SSA + CFGMod {
 /// be burdened with implementing this. All methods must return `Option<T>` to ensure this.
 
 pub trait SSAExtra: SSA {
-    fn mark(&mut self, _: &Self::ValueRef) { }
-    fn clear_mark(&mut self, &Self::ValueRef) { }
-    fn set_color(&mut self, _: &Self::ValueRef, _: u8) { }
-    fn set_comment(&mut self, _: &Self::ValueRef, _: String) { }
-    fn add_flag(&mut self, _: &Self::ValueRef, _: String) { }
+    fn mark(&mut self, _: &Self::ValueRef) {}
+    fn clear_mark(&mut self, &Self::ValueRef) {}
+    fn set_color(&mut self, _: &Self::ValueRef, _: u8) {}
+    fn set_comment(&mut self, _: &Self::ValueRef, _: String) {}
+    fn add_flag(&mut self, _: &Self::ValueRef, _: String) {}
     fn is_marked(&self, _: &Self::ValueRef) -> bool {
         false
     }
@@ -351,7 +364,7 @@ pub trait SSAExtra: SSA {
     }
 }
 
-pub trait SSAWalk<I: Iterator<Item=<Self as SSA>::ValueRef>>: SSA {
+pub trait SSAWalk<I: Iterator<Item = <Self as SSA>::ValueRef>>: SSA {
     fn bfs_walk(&self) -> I;
     fn inorder_walk(&self) -> I;
     fn dfs_walk(&self) -> I;


### PR DESCRIPTION
Changes:
- Disable `take_source_hints` in `rustfmt.toml`
- Unify `c_cfg_builder::handle{cast,binop,uniop}`
- Replace the name of variable `ast` with `cfg`
- Split `c_cfg_builder::update_values` into functions
- Recover `MOpcode::OpLoad` under certain conditions