### PR TITLE
Add size to constant nodes

### DIFF
--- a/src/analysis/functions/fix_ssa_opcalls.rs
+++ b/src/analysis/functions/fix_ssa_opcalls.rs
@@ -52,7 +52,7 @@ fn fix_call_site(
             .iter()
             .find(|x| x.0 == 0)?
             .1;
-        let new_opcall_tgt_node = ssa.insert_const(call_target_addr)?;
+        let new_opcall_tgt_node = ssa.insert_const(call_target_addr, None)?;
         ssa.op_unuse(call_node, old_opcall_tgt_node);
         ssa.op_use(call_node, 0, new_opcall_tgt_node);
     } else {

--- a/src/analysis/inst_combine/mod.rs
+++ b/src/analysis/inst_combine/mod.rs
@@ -109,7 +109,7 @@ impl Combiner {
             Right(c_val) => {
                 // combined to constant
                 radeco_trace!("{:?} = {:#x}", cur_node, c_val);
-                let c_node = ssa.insert_const(c_val)?;
+                let c_node = ssa.insert_const(c_val, None)?;
                 Some(c_node)
             }
         }
@@ -197,12 +197,12 @@ fn make_opinfo_node(
             ssa.op_use(ret, 0, sub_node);
         }
         COCI::Left(new_c) => {
-            let new_cnode = ssa.insert_const(new_c)?;
+            let new_cnode = ssa.insert_const(new_c, None)?;
             ssa.op_use(ret, 0, new_cnode);
             ssa.op_use(ret, 1, sub_node);
         }
         COCI::Right(new_c) => {
-            let new_cnode = ssa.insert_const(new_c)?;
+            let new_cnode = ssa.insert_const(new_c, None)?;
             ssa.op_use(ret, 0, sub_node);
             ssa.op_use(ret, 1, new_cnode);
         }

--- a/src/analysis/matcher/gmatch.rs
+++ b/src/analysis/matcher/gmatch.rs
@@ -554,8 +554,12 @@ mod test {
         let add = ssa
             .insert_op(MOpcode::OpAdd, vt, None)
             .expect("Cannot insert new expressions");
-        let const_1 = ssa.insert_const(1).expect("Cannot insert new constants", None)?;
-        let const_2 = ssa.insert_const(2).expect("Cannot insert new constants", None)?;
+        let const_1 = ssa
+            .insert_const(1, None)
+            .expect("Cannot insert new constants");
+        let const_2 = ssa
+            .insert_const(2, None)
+            .expect("Cannot insert new constants");
         ssa.op_use(add, 0, const_1);
         ssa.op_use(add, 1, const_2);
         ssa.set_entry_node(add);
@@ -573,7 +577,9 @@ mod test {
         let add = ssa
             .insert_op(MOpcode::OpXor, vt, None)
             .expect("Cannot insert new expressions");
-        let const_1 = ssa.insert_const(1).expect("Cannot insert new constants", None)?;
+        let const_1 = ssa
+            .insert_const(1, None)
+            .expect("Cannot insert new constants");
         ssa.op_use(add, 0, const_1);
         ssa.op_use(add, 1, const_1);
         ssa.set_entry_node(add);
@@ -592,8 +598,12 @@ mod test {
             let add = ssa
                 .insert_op(MOpcode::OpAdd, vt, None)
                 .expect("Cannot insert new expressions");
-            let const_1 = ssa.insert_const(1).expect("Cannot insert new constants", None)?;
-            let const_2 = ssa.insert_const(2).expect("Cannot insert new constants", None)?;
+            let const_1 = ssa
+                .insert_const(1, None)
+                .expect("Cannot insert new constants");
+            let const_2 = ssa
+                .insert_const(2, None)
+                .expect("Cannot insert new constants");
             let addr = MAddress::new(0, 0);
             ssa.insert_into_block(add, blk, addr);
             ssa.insert_into_block(const_1, blk, addr);

--- a/src/analysis/matcher/gmatch.rs
+++ b/src/analysis/matcher/gmatch.rs
@@ -554,8 +554,8 @@ mod test {
         let add = ssa
             .insert_op(MOpcode::OpAdd, vt, None)
             .expect("Cannot insert new expressions");
-        let const_1 = ssa.insert_const(1).expect("Cannot insert new constants");
-        let const_2 = ssa.insert_const(2).expect("Cannot insert new constants");
+        let const_1 = ssa.insert_const(1).expect("Cannot insert new constants", None)?;
+        let const_2 = ssa.insert_const(2).expect("Cannot insert new constants", None)?;
         ssa.op_use(add, 0, const_1);
         ssa.op_use(add, 1, const_2);
         ssa.set_entry_node(add);
@@ -573,7 +573,7 @@ mod test {
         let add = ssa
             .insert_op(MOpcode::OpXor, vt, None)
             .expect("Cannot insert new expressions");
-        let const_1 = ssa.insert_const(1).expect("Cannot insert new constants");
+        let const_1 = ssa.insert_const(1).expect("Cannot insert new constants", None)?;
         ssa.op_use(add, 0, const_1);
         ssa.op_use(add, 1, const_1);
         ssa.set_entry_node(add);
@@ -592,8 +592,8 @@ mod test {
             let add = ssa
                 .insert_op(MOpcode::OpAdd, vt, None)
                 .expect("Cannot insert new expressions");
-            let const_1 = ssa.insert_const(1).expect("Cannot insert new constants");
-            let const_2 = ssa.insert_const(2).expect("Cannot insert new constants");
+            let const_1 = ssa.insert_const(1).expect("Cannot insert new constants", None)?;
+            let const_2 = ssa.insert_const(2).expect("Cannot insert new constants", None)?;
             let addr = MAddress::new(0, 0);
             ssa.insert_into_block(add, blk, addr);
             ssa.insert_into_block(const_1, blk, addr);

--- a/src/backend/lang_c/c_cfg_builder.rs
+++ b/src/backend/lang_c/c_cfg_builder.rs
@@ -632,7 +632,7 @@ impl<'a> CCFGDataMap<'a> {
     }
 
     fn prepare_consts(&mut self, cfg: &mut CCFG, strings: &HashMap<u64, String>) {
-        for (&val, &node) in self.ssa.constants.iter() {
+        for (&node, &val) in self.ssa.constants().iter() {
             if self.ssa.node_data(node).is_ok() {
                 // TODO add type
                 let cfg_node = if let Some(s) = strings.get(&val) {

--- a/src/frontend/containers.rs
+++ b/src/frontend/containers.rs
@@ -210,10 +210,13 @@ fn fix_call_info(rfn: &mut DefaultFnTy) {
                 if let Some(info) = call_info.get_mut(&call_site) {
                     if let Some(arg_node) = ssa.operands_of(*call_node).get(0) {
                         let target_node = ssa
-                            .insert_const(info.callee.unwrap_or_else(|| {
-                                radeco_err!("info.callee is None");
-                                0
-                            }))
+                            .insert_const(
+                                info.callee.unwrap_or_else(|| {
+                                    radeco_err!("info.callee is None");
+                                    0
+                                }),
+                                None,
+                            )
                             .unwrap_or_else(|| {
                                 radeco_err!("Cannot insert new constants");
                                 ssa.invalid_value().unwrap()

--- a/src/middle/ir_reader/lowering.rs
+++ b/src/middle/ir_reader/lowering.rs
@@ -272,7 +272,7 @@ impl<'a> LowerSsa<'a> {
                     }
                 }
             }
-            sast::Operand::Const(v) => self.ssa.insert_const(v)?,
+            sast::Operand::Const(v) => self.ssa.insert_const(v, None)?,
         })
     }
 
@@ -290,7 +290,7 @@ impl<'a> LowerSsa<'a> {
                 return Err(LoweringError::InvalidAst(format!(
                     "value defined twice: {:?}",
                     o.key()
-                )))
+                )));
             }
         }
 

--- a/src/middle/phiplacement.rs
+++ b/src/middle/phiplacement.rs
@@ -300,10 +300,11 @@ where
                     .unwrap_or(invalid_edge),
             ];
             for (i, edge) in outgoing.iter().enumerate() {
-                if *edge != self
-                    .ssa
-                    .invalid_edge()
-                    .expect("Invalid Edge is not defined")
+                if *edge
+                    != self
+                        .ssa
+                        .invalid_edge()
+                        .expect("Invalid Edge is not defined")
                 {
                     let target = self
                         .ssa
@@ -698,7 +699,7 @@ where
         vt_option: Option<ValueInfo>,
     ) -> T::ValueRef {
         if vt_option.is_none() {
-            return self.ssa.insert_const(value).unwrap_or_else(|| {
+            return self.ssa.insert_const(value, None).unwrap_or_else(|| {
                 radeco_err!("Cannot insert new constants");
                 self.ssa.invalid_value().unwrap()
             });
@@ -707,7 +708,7 @@ where
         let width = vt.width().get_width().unwrap_or(64);
         if width < 64 {
             let val: u64 = value & (1 << (width) - 1);
-            let const_node = self.ssa.insert_const(val).unwrap_or_else(|| {
+            let const_node = self.ssa.insert_const(val, Some(width)).unwrap_or_else(|| {
                 radeco_err!("Cannot insert new constants");
                 self.ssa.invalid_value().unwrap()
             });
@@ -716,10 +717,13 @@ where
             self.op_use(&narrow_node, 0, &const_node);
             narrow_node
         } else {
-            let const_node = self.ssa.insert_const(value).unwrap_or_else(|| {
-                radeco_err!("Cannot insert new constants");
-                self.ssa.invalid_value().unwrap()
-            });
+            let const_node = self
+                .ssa
+                .insert_const(value, Some(width))
+                .unwrap_or_else(|| {
+                    radeco_err!("Cannot insert new constants");
+                    self.ssa.invalid_value().unwrap()
+                });
             const_node
         }
     }

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -294,7 +294,7 @@ pub trait SSAMod: SSA + CFGMod {
     ) -> Option<Self::ValueRef>;
 
     /// Add a new constant node.
-    fn insert_const(&mut self, value: u64) -> Option<Self::ValueRef>;
+    fn insert_const(&mut self, value: u64, size: Option<u16>) -> Option<Self::ValueRef>;
 
     /// Add a new phi node.
     fn insert_phi(&mut self, vt: ValueInfo) -> Option<Self::ValueRef>;

--- a/src/middle/ssa/ssastorage.rs
+++ b/src/middle/ssa/ssastorage.rs
@@ -1055,15 +1055,10 @@ impl SSAMod for SSAStorage {
         )
     }
 
-    fn insert_const(&mut self, value: u64) -> Option<Self::ValueRef> {
-        if self.constants.contains_key(&value) {
-            Some(self.constants.get(&value).unwrap().clone())
-        } else {
-            let data = NodeData::Op(MOpcode::OpConst(value), scalar!(64));
-            let id = self.insert_node(data).expect("Cannot insert new nodes");
-            self.constants.insert(value, id);
-            Some(id)
-        }
+    fn insert_const(&mut self, value: u64, size: Option<u16>) -> Option<Self::ValueRef> {
+        let data = NodeData::Op(MOpcode::OpConst(value), scalar!(size.unwrap_or(64)));
+        let id = self.insert_node(data).expect("Cannot insert new nodes");
+        Some(id)
     }
 
     fn insert_phi(&mut self, vt: ValueInfo) -> Option<Self::ValueRef> {

--- a/src/middle/ssa/verifier.rs
+++ b/src/middle/ssa/verifier.rs
@@ -218,20 +218,6 @@ impl Verify for SSAStorage {
                         check!(op_len == n, SSAErr::WrongNumOperands(*exi, n, op_len));
                     }
 
-                    for op in &operands {
-                        if let Some(val) = self.constant(*op) {
-                            check!(
-                                self.constants.get(&val).is_some(),
-                                SSAErr::UnrecordedConstant(val)
-                            );
-                            let const_node = self.constants.get(&val).unwrap();
-                            check!(
-                                const_node == op,
-                                SSAErr::MultiConstantCopy(val, *const_node, *op)
-                            );
-                        }
-                    }
-
                     // TODO: We do not consider OpStore and OpLoad's width now.
                     operands.retain(&opfilter);
 


### PR DESCRIPTION
This PR is for removing redundant casts.
For example, 
```
%1: eax
%2 = Narrow32(0x1234)
%3 = %1 + %2
```
will be
```
%1: eax
%2 = %1 + 0x1234
```
This will improve the result of inst_combine.

Related to #216 