### PR TITLE
Convert bitmask to OpNarrow

### DIFF
--- a/src/analysis/mask2narrow.rs
+++ b/src/analysis/mask2narrow.rs
@@ -1,0 +1,63 @@
+//! Module that implements translation from bit mask to MOpcode::OpNarrow
+
+use middle::ir::MOpcode;
+use middle::ssa::cfg_traits::CFG;
+use middle::ssa::ssa_traits::{SSAMod, ValueInfo, SSA};
+use middle::ssa::ssastorage::SSAStorage;
+use petgraph::graph::NodeIndex;
+
+fn mask2narrow(ssa: &SSAStorage, expr: NodeIndex) -> Option<MOpcode> {
+    let width = ssa
+        .node_data(expr)
+        .ok()
+        .and_then(|nd| nd.vt.width().get_width());
+    match (ssa.constant_value(expr), width) {
+        (Some(0xffffffffffffffff), Some(64)) => Some(MOpcode::OpNarrow(64)),
+        (Some(x), Some(_)) if (x + 1).count_ones() == 1 => {
+            Some(MOpcode::OpNarrow((x + 1).trailing_zeros() as u16))
+        }
+        _ => None,
+    }
+}
+
+pub fn run(ssa: &mut SSAStorage) {
+    let it = ssa
+        .blocks()
+        .into_iter()
+        .flat_map(|b| ssa.exprs_in(b))
+        .filter(|&e| match ssa.opcode(e) {
+            Some(MOpcode::OpAnd) => true,
+            _ => false,
+        })
+        .collect::<Vec<_>>();
+
+    for node in it {
+        let mut _ops = ssa.operands_of(node);
+        let mut ops = _ops.iter().take(2).cloned();
+        if let (Some(x), Some(y)) = (ops.next(), ops.next()) {
+            visit_expr(ssa, node, x, y);
+            visit_expr(ssa, node, y, x);
+        }
+    }
+}
+
+fn visit_expr(ssa: &mut SSAStorage, expr: NodeIndex, n: NodeIndex, mask: NodeIndex) -> Option<()> {
+    let op = mask2narrow(ssa, mask)?;
+    let vt = {
+        let w = match op {
+            MOpcode::OpNarrow(w) => w,
+            _ => panic!(),
+        };
+        let mut x = scalar!(w);
+        let vty = ssa.node_data(expr).ok()?.vt.vty;
+        x.vty = vty;
+        x
+    };
+    let addr = ssa.address(expr)?;
+    let blk = ssa.block_for(expr)?;
+    let new_op = ssa.insert_op(op, vt, Some(addr.address))?;
+    ssa.op_use(new_op, 0, n);
+    ssa.replace_value(expr, new_op);
+    ssa.insert_into_block(new_op, blk, addr);
+    None
+}

--- a/src/analysis/mask2narrow.rs
+++ b/src/analysis/mask2narrow.rs
@@ -7,14 +7,21 @@ use middle::ssa::ssastorage::SSAStorage;
 use petgraph::graph::NodeIndex;
 
 fn mask2narrow(ssa: &SSAStorage, expr: NodeIndex) -> Option<MOpcode> {
-    let width = ssa
+    let width_opt = ssa
         .node_data(expr)
         .ok()
         .and_then(|nd| nd.vt.width().get_width());
-    match (ssa.constant_value(expr), width) {
-        (Some(0xffffffffffffffff), Some(64)) => Some(MOpcode::OpNarrow(64)),
-        (Some(x), Some(_)) if (x + 1).count_ones() == 1 => {
-            Some(MOpcode::OpNarrow((x + 1).trailing_zeros() as u16))
+    // The width returned by OpNarrow should be less than the width of operand.
+    // In case the width will be the same size to the operand, it returns OpMov
+    match (ssa.constant_value(expr), width_opt) {
+        (Some(0xffffffffffffffff), Some(64)) => Some(MOpcode::OpMov),
+        (Some(x), Some(w)) if (x + 1).count_ones() == 1 => {
+            let n = (x + 1).trailing_zeros() as u16;
+            if n == w {
+                Some(MOpcode::OpMov)
+            } else {
+                Some(MOpcode::OpNarrow(n))
+            }
         }
         _ => None,
     }
@@ -43,21 +50,36 @@ pub fn run(ssa: &mut SSAStorage) {
 
 fn visit_expr(ssa: &mut SSAStorage, expr: NodeIndex, n: NodeIndex, mask: NodeIndex) -> Option<()> {
     let op = mask2narrow(ssa, mask)?;
-    let vt = {
-        let w = match op {
-            MOpcode::OpNarrow(w) => w,
-            _ => panic!(),
-        };
-        let mut x = scalar!(w);
-        let vty = ssa.node_data(expr).ok()?.vt.vty;
-        x.vty = vty;
-        x
-    };
+    let vt = ssa.node_data(expr).ok()?.vt;
     let addr = ssa.address(expr)?;
     let blk = ssa.block_for(expr)?;
-    let new_op = ssa.insert_op(op, vt, Some(addr.address))?;
-    ssa.op_use(new_op, 0, n);
-    ssa.replace_value(expr, new_op);
-    ssa.insert_into_block(new_op, blk, addr);
+    match op {
+        MOpcode::OpMov => {
+            let new_op = ssa.insert_op(op, vt, Some(addr.address))?;
+            ssa.op_use(new_op, 0, n);
+            ssa.replace_value(expr, new_op);
+            ssa.insert_into_block(new_op, blk, addr);
+        }
+        MOpcode::OpNarrow(w) => {
+            let narrowed_op = {
+                let mut x = scalar!(w);
+                x.vty = vt.vty;
+                ssa.insert_op(op, x, Some(addr.address))
+            }?;
+            let extended_op = {
+                let www = vt
+                    .width()
+                    .get_width()
+                    .expect("vt.width() should not be `None`");
+                ssa.insert_op(MOpcode::OpZeroExt(www), vt, Some(addr.address))
+            }?;
+            ssa.op_use(narrowed_op, 0, n);
+            ssa.op_use(extended_op, 0, narrowed_op);
+            ssa.insert_into_block(narrowed_op, blk, addr);
+            ssa.insert_into_block(extended_op, blk, addr);
+            ssa.replace_value(expr, extended_op);
+        }
+        _ => unreachable!(),
+    };
     None
 }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -28,6 +28,7 @@ pub mod copy_propagation;
 pub mod functions;
 pub mod inst_combine;
 pub mod interproc;
+pub mod mask2narrow;
 pub mod reference_marking;
 pub mod tie;
 pub mod vsa;

--- a/src/middle/ssa/ssa_traits.rs
+++ b/src/middle/ssa/ssa_traits.rs
@@ -21,7 +21,8 @@
 //! The associated type `SSA::ValueRef` is used by the methods to refer to
 //! nodes.
 
-use std::fmt::{self, Debug};
+use std::fmt;
+use std::fmt::Debug;
 use std::hash::Hash;
 
 use super::cfg_traits::{CFGMod, CFG};
@@ -87,7 +88,7 @@ macro_rules! scalar {
     ($w:expr) => {
         ValueInfo::new(
             $crate::middle::ssa::ssa_traits::ValueType::Scalar,
-            ir::WidthSpec::new_known($w),
+            $crate::middle::ir::WidthSpec::new_known($w),
         )
     };
 }
@@ -96,13 +97,13 @@ macro_rules! reference {
     () => {
         ValueInfo::new(
             $crate::middle::ssa::ssa_traits::ValueType::Reference,
-            ir::WidthSpec::Unknown,
+            $crate::middle::ir::WidthSpec::Unknown,
         )
     };
     ($w:expr) => {
         ValueInfo::new(
             $crate::middle::ssa::ssa_traits::ValueType::Reference,
-            ir::WidthSpec::new_known($w),
+            $crate::middle::ir::WidthSpec::new_known($w),
         )
     };
 }

--- a/src/middle/ssa/ssastorage.rs
+++ b/src/middle/ssa/ssastorage.rs
@@ -7,7 +7,7 @@
 
 //! Module that holds the struct and trait implementations for the ssa form.
 
-use middle::ir::{self, MAddress, MOpcode};
+use middle::ir::{MAddress, MOpcode};
 use middle::regfile::SubRegisterFile;
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::stable_graph::StableDiGraph;
@@ -25,7 +25,7 @@ use super::ssa_traits::NodeData as TNodeData;
 use super::ssa_traits::NodeType as TNodeType;
 use super::ssa_traits::{SSAExtra, SSAMod, SSAWalk, ValueInfo, SSA};
 
-#[cfg(feature="trace_log")]
+#[cfg(feature = "trace_log")]
 use utils::logger;
 
 /// Structure that represents data that maybe associated with an node in the


### PR DESCRIPTION
Related to https://github.com/radareorg/radeco-lib/issues/216
The examples are following
```
v & 0xffffffff => v as 32
v & 0xffff => v as 16
v & 0x1    => v as 1
```

## TODO

```
[*] Found Error: NodeIndex(387) expected with to be 32, found width: 32.
```
The above error is reported by SSAVerifier.

This can be reproduced with following steps.
```
>> load bins/crackme0x00
...
>> analyze main
[+] Analyzing: main @ 0x8048414
...
>> analyze main
[+] Analyzing: main @ 0x8048414
...
  [*] Found Error: NodeIndex(387) expected with to be 32, found width: 32.
```