### PR TITLE
Use a policy to selectively commit changes to the IR

### DIFF
--- a/src/analysis/analyzer.rs
+++ b/src/analysis/analyzer.rs
@@ -1,6 +1,8 @@
 use std::any::Any;
 use std::fmt::Debug;
 
+use petgraph::graph::NodeIndex;
+
 use frontend::radeco_containers::{RadecoFunction, RadecoModule};
 
 /// This trait provides access to extra informations generated during the analysis pass.
@@ -19,26 +21,85 @@ pub enum AnalyzerKind {
     SCCP,
 }
 
-/// Basic trait for all analyzers.
+/// Basic trait for all the analyzers.
 pub trait Analyzer : Any + Debug {
-    /// Return the name of this `Analyzer`.
+    /// Returns the name of this `Analyzer`.
     fn name(&self) -> String;
 
-    /// Return the kind of this `Analyzer`.
+    /// Returns the kind of this `Analyzer`.
     fn kind(&self) -> AnalyzerKind;
 
-    /// Return a list of `Analyzer`s to run before this one.
+    /// Returns a list of `Analyzer`s to run before this one.
     fn requires(&self) -> Vec<AnalyzerKind>;
+
+    /// Returns `true` if this `Analyzer` uses a policy function to decide whether to apply or not
+    /// `Changes` to the IR. In this case a policy function must be provided when calling `analyze`.
+    /// Returns `false` if this `Analyzer` does not use a policy function and changes directly the
+    /// IR. Any policy function passed to `analyze` is ignored by this kind of analyzers.
+    ///
+    /// The former is the type of `Analyzer`s which (typically) produce one single atomic `Change`
+    /// at time, e.g. `DCE` removes useless expressions one by one. Interrupting their work in the
+    /// middle will still deliver some useful output.
+    ///
+    /// The latter type of `Analyzer`s are module-oriented, meaning that they work on the entire
+    /// function/module at the same time and it does not make sense to split their work into smaller
+    /// atomic `Change`s.
+    fn uses_policy(&self) -> bool;
+}
+
+/// An atomic change to the IR.
+///
+/// It represents a high-level, `Analyzer` specific change to apply to the IR.
+pub trait Change : Any + Debug { }
+
+/// A `Change` which replaces a node with another.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplaceValue(pub NodeIndex, pub NodeIndex);
+impl Change for ReplaceValue { }
+
+/// A `Change` which removes a node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemoveValue(pub NodeIndex);
+impl Change for RemoveValue { }
+
+/// An `Action` to take with respect to a `Change`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Action {
+    Apply,
+    Skip,
+    Abort,
+}
+
+/// Short-hand policy to apply all the `Change`s.
+pub fn all(_change: Box<Change>) -> Action {
+    Action::Apply
+}
+
+/// Short-hand policy to skip all the `Changes`s.
+pub fn none(_change: Box<Change>) -> Action {
+    Action::Skip
 }
 
 /// An `Analyzer` that takes a function.
 pub trait FuncAnalyzer : Analyzer {
-    fn analyze(&mut self, func: &mut RadecoFunction) -> Option<Box<AnalyzerResult>>;
+    /// Look for possbile `Change`s to apply to `func`. When one is found `policy` is called with
+    /// that `Change` as parameter; then according to the return value it is applied or discarded.
+    ///
+    /// As `Change`s are applied, the IR is not the same as before, thus `Change`s previously
+    /// discarded could be proposed again by the `Analyer`. On the other hand an `Analyzer` is
+    /// not expected to propose again a `Change` if all the previous other `Change`s were skipped.
+    fn analyze<T: Fn(Box<Change>) -> Action>(&mut self, func: &mut RadecoFunction, policy: Option<T>) -> Option<Box<AnalyzerResult>>;
 }
 
 /// An `Analyzer` that takes a module.
 pub trait ModuleAnalyzer : Analyzer {
-    fn analyze(&mut self, module: &mut RadecoModule) -> Option<Box<AnalyzerResult>>;
+    /// Look for possbile `Change`s to apply to `mod`. When one is found `policy` is called with
+    /// that `Change` as parameter; then according to the return value it is applied or discarded.
+    ///
+    /// As `Change`s are applied, the IR is not the same as before, thus `Change`s previously
+    /// discarded could be proposed again by the `Analyer`. On the other hand an `Analyzer` is
+    /// not expected to propose again a `Change` if all the previous other `Change`s were skipped.
+    fn analyze<T: Fn(Box<Change>) -> Action>(&mut self, module: &mut RadecoModule, policy: Option<T>) -> Option<Box<AnalyzerResult>>;
 }
 
 /// Get all the available `FuncAnalyzer`s

--- a/src/analysis/copy_propagation/mod.rs
+++ b/src/analysis/copy_propagation/mod.rs
@@ -1,26 +1,46 @@
-use analysis::analyzer::{Analyzer, AnalyzerKind, AnalyzerResult, FuncAnalyzer};
+use analysis::analyzer::{Action, Analyzer, AnalyzerKind, AnalyzerResult, Change, FuncAnalyzer, ReplaceValue};
 use frontend::radeco_containers::RadecoFunction;
 use middle::ir::MOpcode;
 use middle::ssa::cfg_traits::CFG;
 use middle::ssa::ssa_traits::*;
 use middle::ssa::ssastorage::SSAStorage;
 
-use petgraph::graph::NodeIndex;
-
 use std::collections::HashSet;
 
 #[derive(Debug)]
-pub struct CopyPropagation;
+pub struct CopyPropagation {
+    skip: Vec<ReplaceValue>,
+}
 
 impl CopyPropagation {
     pub fn new() -> Self {
-        CopyPropagation
+        CopyPropagation {
+            skip: Vec::new()
+        }
+    }
+
+    fn gather_copies(ssa: &SSAStorage) -> Vec<ReplaceValue> {
+        ssa.blocks()
+            .into_iter()
+            .flat_map(|b| ssa.exprs_in(b))
+            .filter_map(|e| match ssa.opcode(e) {
+                Some(MOpcode::OpMov) => {
+                    if let Some(&o) = ssa.operands_of(e).iter().nth(0) {
+                        Some(ReplaceValue(o, e))
+                    } else {
+                        radeco_err!("No operand of `OpMov` found");
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>()
     }
 }
 
 impl Analyzer for CopyPropagation {
     fn name(&self) -> String {
-        return "copy_propagation".to_owned()
+        return "copy_propagation".to_owned();
     }
 
     fn kind(&self) -> AnalyzerKind {
@@ -30,50 +50,56 @@ impl Analyzer for CopyPropagation {
     fn requires(&self) -> Vec<AnalyzerKind> {
         Vec::new()
     }
+
+    fn uses_policy(&self) -> bool {
+        true
+    }
 }
 
 impl FuncAnalyzer for CopyPropagation {
-    fn analyze(&mut self, func: &mut RadecoFunction) -> Option<Box<AnalyzerResult>> {
+    fn analyze<T: Fn(Box<Change>) -> Action>(
+        &mut self,
+        func: &mut RadecoFunction,
+        policy: Option<T>,
+    ) -> Option<Box<AnalyzerResult>> {
+        let policy = policy.expect("A policy function must be provided");
         let ssa = func.ssa_mut();
         loop {
-            let copies = CopyInfo::gather_copies(&ssa);
+            let copies = CopyPropagation::gather_copies(&ssa)
+                .into_iter()
+                .filter(|change| !self.skip.contains(change))
+                .collect::<Vec<_>>();
+
             if copies.is_empty() {
                 break;
             }
+
             let mut replaced = HashSet::new();
-            for CopyInfo(from, to) in copies {
+            for change in copies {
+                let from = change.0;
+                let to = change.1;
+
                 if replaced.contains(&from) {
                     continue;
                 }
-                replaced.insert(to);
-                ssa.replace_value(to, from);
+
+                match policy(Box::new(change)) {
+                    Action::Apply => {
+                        replaced.insert(to);
+                        ssa.replace_value(to, from);
+                        self.skip.clear();
+                    },
+                    Action::Skip => {
+                        self.skip.push(change);
+                    },
+                    Action::Abort => {
+                        return None;
+                    }
+                }
+
             }
         }
 
         None
-    }
-}
-
-type From = NodeIndex;
-type To = NodeIndex;
-struct CopyInfo(From, To);
-
-impl CopyInfo {
-    fn gather_copies(ssa: &SSAStorage) -> Vec<Self> {
-        ssa.blocks()
-            .into_iter()
-            .flat_map(|b| ssa.exprs_in(b))
-            .filter_map(|e| match ssa.opcode(e) {
-                Some(MOpcode::OpMov) => {
-                    if let Some(&o) = ssa.operands_of(e).iter().nth(0) {
-                        Some(CopyInfo(o, e))
-                    } else {
-                        radeco_err!("No operand of `OpMov` found");
-                        None
-                    }
-                }
-                _ => None,
-            })
-            .collect::<Vec<_>>()
     }
 }

--- a/src/analysis/functions/fix_ssa_opcalls.rs
+++ b/src/analysis/functions/fix_ssa_opcalls.rs
@@ -7,7 +7,7 @@
 //! [`OpCall`]: ir::MOpcode::OpCall
 //! [the callgraph]: RadecoModule::callgraph
 
-use analysis::analyzer::{Analyzer, AnalyzerKind, AnalyzerResult, ModuleAnalyzer};
+use analysis::analyzer::{Action, Analyzer, AnalyzerKind, AnalyzerResult, Change, ModuleAnalyzer};
 use frontend::radeco_containers::*;
 use middle::ir;
 use middle::ssa::ssa_traits::*;
@@ -36,10 +36,16 @@ impl Analyzer for CallSiteFixer {
     fn requires(&self) -> Vec<AnalyzerKind> {
         Vec::new()
     }
+
+    fn uses_policy(&self) -> bool {
+        // There is no point in fixing some sites and skipping
+        // some others.
+        false
+    }
 }
 
 impl ModuleAnalyzer for CallSiteFixer {
-    fn analyze(&mut self, rmod: &mut RadecoModule) -> Option<Box<AnalyzerResult>> {
+    fn analyze<T: Fn(Box<Change>) -> Action>(&mut self, rmod: &mut RadecoModule, _policy: Option<T>) -> Option<Box<AnalyzerResult>> {
         for rfun in rmod.functions.values_mut() {
             go_fn(rfun, &rmod.callgraph);
         }

--- a/src/analysis/interproc/digstack.rs
+++ b/src/analysis/interproc/digstack.rs
@@ -279,7 +279,7 @@ mod test {
     use std::fs::File;
     use std::io::prelude::*;
 
-    use analysis::analyzer::FuncAnalyzer;
+    use analysis::analyzer::{FuncAnalyzer, all};
     use analysis::dce::DCE;
     use frontend::radeco_containers::RadecoFunction;
     use frontend::ssaconstructor::SSAConstruct;
@@ -309,7 +309,7 @@ mod test {
         }
 
         let mut dce = DCE::new();
-        dce.analyze(&mut rfn);
+        dce.analyze(&mut rfn, Some(all));
 
         frontward_analysis(rfn.ssa(), "rsp".to_string(), "rbp".to_string());
         backward_analysis(rfn.ssa(), "rsp".to_string());
@@ -336,7 +336,7 @@ mod test {
         }
 
         let mut dce = DCE::new();
-        dce.analyze(&mut rfn);
+        dce.analyze(&mut rfn, Some(all));
 
         frontward_analysis(rfn.ssa(), "rsp".to_string(), "rbp".to_string());
         backward_analysis(rfn.ssa(), "rsp".to_string());

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -923,7 +923,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use analysis::analyzer::FuncAnalyzer;
+    use analysis::analyzer::{FuncAnalyzer, all};
     use analysis::sccp::SCCP;
     use analysis::dce::DCE;
     use middle::ir_writer;
@@ -967,7 +967,7 @@ mod test {
         }
 
         let mut dce = DCE::new();
-        dce.analyze(&mut rfn);
+        dce.analyze(&mut rfn, Some(all));
 
         let tmp = dot::emit_dot(rfn.ssa());
         let mut f = File::create("yay.dot").unwrap();
@@ -992,12 +992,12 @@ mod test {
         }
 
         let mut dce = DCE::new();
-        dce.analyze(&mut rfn);
+        dce.analyze(&mut rfn, Some(all));
 
         let mut analyzer = SCCP::new();
-        analyzer.analyze(&mut rfn);
+        analyzer.analyze(&mut rfn, Some(all));
 
-        dce.analyze(&mut rfn);
+        dce.analyze(&mut rfn, Some(all));
 
         let tmp = dot::emit_dot(rfn.ssa());
         let mut f = File::create("yay.dot").unwrap();
@@ -1023,7 +1023,7 @@ mod test {
         }
 
         let mut dce = DCE::new();
-        dce.analyze(&mut rfn);
+        dce.analyze(&mut rfn, Some(all));
 
         println!("\nBefore Constant Propagation:");
         let mut il = String::new();
@@ -1031,9 +1031,9 @@ mod test {
         println!("{}", il);
 
         let mut analyzer = SCCP::new();
-        analyzer.analyze(&mut rfn);
+        analyzer.analyze(&mut rfn, Some(all));
 
-        dce.analyze(&mut rfn);
+        dce.analyze(&mut rfn, Some(all));
 
         println!("\nAfter Constant Propagation:");
         let mut il = String::new();


### PR DESCRIPTION
Hi, @XVilka  @kriw  @chinmaydd 
Inside #239 we decided not to implement a mechanism to pick/discard changes because that would not be easy to implement. Here I'm proposing to add a function that is called on the fly (by the analyzer) to decide whether to pick or not changes. This way the overall complexity can be mantained low but at the same time, the consumer has the flexibility to drop unwanted changes.
I implemented this mechanism only for `CopyPropagation` (as a showcase).

Let me know If you like this idea. Thank you.