### PR TITLE
Import arithmetic patterns from an external file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,17 @@ before_script:
       export CC=gcc-7 && export CXX=g++7 &&
       git clone https://github.com/aquynh/capstone.git &&
       cd ./capstone && ./make.sh && sudo ./make.sh install && cd ../
+  # Install rustfmt
+  - |
+      rustup component add rustfmt
 
 script:
   - |
     travis-cargo build &&
     travis-cargo test &&
+    chmod 644 src/middle/ir_reader/parser.rs &&
+    rustfmt src/middle/ir_reader/parser.rs
+    travis-cargo fmt -- -- --check &&
     travis-cargo bench
 after_success:
   - travis-cargo --only nightly coveralls --no-sudo --verify

--- a/analysis/patterns
+++ b/analysis/patterns
@@ -1,0 +1,8 @@
+(OpNarrow1 (OpXor #x1, (OpSub %1, %2))) => (OpEq %1, %2))
+(OpNot (OpOr (OpEq %1, %2), (OpMov (OpLt %1, (OpSub %1, %2))))) => (OpGt %1, %2))
+(OpNot (OpMov (OpLt %1, (OpSub %1, %2))))  => (OpOr (OpGt %1, %2), (OpEq %1, %2)))
+(OpMov (OpLt %1, (OpSub %1, %2))) => (OpLt %1, %2))
+(OpOr (OpEq %1, %2), (OpLt %1, %2)) => (OpOr (OpLt %1, %2), (OpEq %1, %2)))
+(OpXor %1, %1) => (OpConst #x0))
+(OpMul %1, #x0) => (OpConst #x0)
+(OpMul %1, #x1) => (OpConst %1)

--- a/src/analysis/analyzer.rs
+++ b/src/analysis/analyzer.rs
@@ -4,14 +4,14 @@ use std::fmt::Debug;
 
 use petgraph::graph::NodeIndex;
 
-use analysis::{arithmetic, copy_propagation, dce, inst_combine, sccp};
 use analysis::cse::cse;
 use analysis::functions::{fix_ssa_opcalls, infer_regusage};
 use analysis::interproc::interproc;
+use analysis::{arithmetic, copy_propagation, dce, inst_combine, sccp};
 use frontend::radeco_containers::{RadecoFunction, RadecoModule};
 
 /// This trait provides access to extra informations generated during the analysis pass.
-pub trait AnalyzerResult : Any + Debug {
+pub trait AnalyzerResult: Any + Debug {
     fn as_any(&self) -> &dyn Any;
 }
 
@@ -62,21 +62,21 @@ pub struct AnalyzerInfo {
 impl From<AnalyzerKind> for &'static AnalyzerInfo {
     fn from(kind: AnalyzerKind) -> &'static AnalyzerInfo {
         match kind {
-            AnalyzerKind::Arithmetic      => &arithmetic::INFO,
-            AnalyzerKind::CallSiteFixer   => &fix_ssa_opcalls::INFO,
-            AnalyzerKind::Combiner        => &inst_combine::INFO,
+            AnalyzerKind::Arithmetic => &arithmetic::INFO,
+            AnalyzerKind::CallSiteFixer => &fix_ssa_opcalls::INFO,
+            AnalyzerKind::Combiner => &inst_combine::INFO,
             AnalyzerKind::CopyPropagation => &copy_propagation::INFO,
-            AnalyzerKind::CSE             => &cse::INFO,
-            AnalyzerKind::DCE             => &dce::INFO,
-            AnalyzerKind::Inferer         => &infer_regusage::INFO,
-            AnalyzerKind::InterProc       => &interproc::INFO,
-            AnalyzerKind::SCCP            => &sccp::INFO,
+            AnalyzerKind::CSE => &cse::INFO,
+            AnalyzerKind::DCE => &dce::INFO,
+            AnalyzerKind::Inferer => &infer_regusage::INFO,
+            AnalyzerKind::InterProc => &interproc::INFO,
+            AnalyzerKind::SCCP => &sccp::INFO,
         }
     }
 }
 
 /// Basic trait for all the analyzers.
-pub trait Analyzer : Any + Debug {
+pub trait Analyzer: Any + Debug {
     fn info(&self) -> &'static AnalyzerInfo;
     fn as_any(&self) -> &dyn Any;
 }
@@ -84,7 +84,7 @@ pub trait Analyzer : Any + Debug {
 /// An atomic change to the IR.
 ///
 /// It represents a high-level, `Analyzer` specific change to apply to the IR.
-pub trait Change : Any + Debug {
+pub trait Change: Any + Debug {
     fn as_any(&self) -> &dyn Any;
 }
 
@@ -92,14 +92,18 @@ pub trait Change : Any + Debug {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReplaceValue(pub NodeIndex, pub NodeIndex);
 impl Change for ReplaceValue {
-    fn as_any(&self) -> &dyn Any { self }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 /// A `Change` which removes a node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RemoveValue(pub NodeIndex);
 impl Change for RemoveValue {
-    fn as_any(&self) -> &dyn Any { self }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 /// An `Action` to take with respect to a `Change`.
@@ -121,40 +125,52 @@ pub fn none(_change: Box<Change>) -> Action {
 }
 
 /// An `Analyzer` that takes a function.
-pub trait FuncAnalyzer : Analyzer {
+pub trait FuncAnalyzer: Analyzer {
     /// Look for possbile `Change`s to apply to `func`. When one is found `policy` is called with
     /// that `Change` as parameter; then according to the return value it is applied or discarded.
     ///
     /// As `Change`s are applied, the IR is not the same as before, thus `Change`s previously
     /// discarded could be proposed again by the `Analyer`. On the other hand an `Analyzer` is
     /// not expected to propose again a `Change` if all the previous other `Change`s were skipped.
-    fn analyze<T: FnMut(Box<Change>) -> Action>(&mut self, func: &mut RadecoFunction, policy: Option<T>) -> Option<Box<AnalyzerResult>>;
+    fn analyze<T: FnMut(Box<Change>) -> Action>(
+        &mut self,
+        func: &mut RadecoFunction,
+        policy: Option<T>,
+    ) -> Option<Box<AnalyzerResult>>;
 }
 
 /// An `Analyzer` that takes a module.
-pub trait ModuleAnalyzer : Analyzer {
+pub trait ModuleAnalyzer: Analyzer {
     /// Look for possbile `Change`s to apply to `mod`. When one is found `policy` is called with
     /// that `Change` as parameter; then according to the return value it is applied or discarded.
     ///
     /// As `Change`s are applied, the IR is not the same as before, thus `Change`s previously
     /// discarded could be proposed again by the `Analyer`. On the other hand an `Analyzer` is
     /// not expected to propose again a `Change` if all the previous other `Change`s were skipped.
-    fn analyze<T: FnMut(Box<Change>) -> Action>(&mut self, module: &mut RadecoModule, policy: Option<T>) -> Option<Box<AnalyzerResult>>;
+    fn analyze<T: FnMut(Box<Change>) -> Action>(
+        &mut self,
+        module: &mut RadecoModule,
+        policy: Option<T>,
+    ) -> Option<Box<AnalyzerResult>>;
 }
 
 /// Get all the available `FuncAnalyzer`s
 pub fn all_func_analyzers() -> Vec<AnalyzerKind> {
-    vec![AnalyzerKind::Arithmetic,
-         AnalyzerKind::Combiner,
-         AnalyzerKind::CopyPropagation,
-         AnalyzerKind::CSE,
-         AnalyzerKind::DCE,
-         AnalyzerKind::SCCP]
+    vec![
+        AnalyzerKind::Arithmetic,
+        AnalyzerKind::Combiner,
+        AnalyzerKind::CopyPropagation,
+        AnalyzerKind::CSE,
+        AnalyzerKind::DCE,
+        AnalyzerKind::SCCP,
+    ]
 }
 
 /// Get all the available `ModuleAnalyzer`s
 pub fn all_module_analyzers() -> Vec<AnalyzerKind> {
-    vec![AnalyzerKind::CallSiteFixer,
-         AnalyzerKind::Inferer,
-         AnalyzerKind::InterProc]
+    vec![
+        AnalyzerKind::CallSiteFixer,
+        AnalyzerKind::Inferer,
+        AnalyzerKind::InterProc,
+    ]
 }

--- a/src/analysis/arithmetic.rs
+++ b/src/analysis/arithmetic.rs
@@ -1,6 +1,8 @@
-use analysis::analyzer::{Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, FuncAnalyzer};
-use frontend::radeco_containers::RadecoFunction;
+use analysis::analyzer::{
+    Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, FuncAnalyzer,
+};
 use analysis::matcher::gmatch;
+use frontend::radeco_containers::RadecoFunction;
 
 use std::any::Any;
 use std::io;
@@ -52,7 +54,9 @@ pub struct ArithChange {
 }
 
 impl Change for ArithChange {
-    fn as_any(&self) -> &dyn Any { self }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 const NAME: &str = "arithmetic";
@@ -67,7 +71,7 @@ pub const INFO: AnalyzerInfo = AnalyzerInfo {
 
 #[derive(Debug)]
 pub struct Arithmetic {
-    replace_patterns: Vec<(String, String)>
+    replace_patterns: Vec<(String, String)>,
 }
 
 impl Arithmetic {
@@ -81,16 +85,23 @@ impl Arithmetic {
             replace_patterns: replace_patterns,
         }
     }
-
 }
 
 impl Analyzer for Arithmetic {
-    fn info(&self) -> &'static AnalyzerInfo { &INFO }
-    fn as_any(&self) -> &dyn Any { self }
+    fn info(&self) -> &'static AnalyzerInfo {
+        &INFO
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl FuncAnalyzer for Arithmetic {
-    fn analyze<T: FnMut(Box<Change>) -> Action>(&mut self, func: &mut RadecoFunction, policy: Option<T>) -> Option<Box<AnalyzerResult>> {
+    fn analyze<T: FnMut(Box<Change>) -> Action>(
+        &mut self,
+        func: &mut RadecoFunction,
+        policy: Option<T>,
+    ) -> Option<Box<AnalyzerResult>> {
         let mut policy = policy.expect("A policy function must be provided");
         let ssa = func.ssa_mut();
 
@@ -99,17 +110,17 @@ impl FuncAnalyzer for Arithmetic {
             let grep = matcher.grep(old.to_string());
 
             for m in grep {
-                let action = policy(Box::new(ArithChange{
+                let action = policy(Box::new(ArithChange {
                     old: m.get_root().clone(),
                     old_expr: old.clone(),
                     new_expr: new.clone(),
-                    bindings: m.get_bindings().clone()
+                    bindings: m.get_bindings().clone(),
                 }));
 
                 match action {
                     Action::Apply => {
                         matcher.replace_value(m, new.clone());
-                    },
+                    }
                     Action::Skip => (),
                     Action::Abort => return None,
                 };

--- a/src/analysis/copy_propagation/mod.rs
+++ b/src/analysis/copy_propagation/mod.rs
@@ -1,4 +1,7 @@
-use analysis::analyzer::{Action, Analyzer, AnalyzerKind, AnalyzerInfo, AnalyzerResult, Change, FuncAnalyzer, ReplaceValue};
+use analysis::analyzer::{
+    Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, FuncAnalyzer,
+    ReplaceValue,
+};
 use frontend::radeco_containers::RadecoFunction;
 use middle::ir::MOpcode;
 use middle::ssa::cfg_traits::CFG;
@@ -15,9 +18,7 @@ pub struct CopyPropagation {
 
 impl CopyPropagation {
     pub fn new() -> Self {
-        CopyPropagation {
-            skip: Vec::new()
-        }
+        CopyPropagation { skip: Vec::new() }
     }
 
     fn gather_copies(ssa: &SSAStorage) -> Vec<ReplaceValue> {
@@ -50,8 +51,12 @@ pub const INFO: AnalyzerInfo = AnalyzerInfo {
 };
 
 impl Analyzer for CopyPropagation {
-    fn info(&self) -> &'static AnalyzerInfo { &INFO }
-    fn as_any(&self) -> &dyn Any { self }
+    fn info(&self) -> &'static AnalyzerInfo {
+        &INFO
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl FuncAnalyzer for CopyPropagation {
@@ -86,15 +91,14 @@ impl FuncAnalyzer for CopyPropagation {
                         replaced.insert(to);
                         ssa.replace_value(to, from);
                         self.skip.clear();
-                    },
+                    }
                     Action::Skip => {
                         self.skip.push(change);
-                    },
+                    }
                     Action::Abort => {
                         return None;
                     }
                 }
-
             }
         }
 

--- a/src/analysis/cse/cse.rs
+++ b/src/analysis/cse/cse.rs
@@ -9,17 +9,19 @@
 use std::any::Any;
 use std::collections::HashMap;
 
+use analysis::analyzer::{
+    Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, FuncAnalyzer,
+    ReplaceValue,
+};
 use frontend::radeco_containers::RadecoFunction;
-use analysis::analyzer::{Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, FuncAnalyzer, ReplaceValue};
 
 use middle::ir::MOpcode;
-use middle::ssa::ssa_traits::{NodeType, SSAMod, SSAWalk};
 use middle::ssa::ssa_traits::SSA;
+use middle::ssa::ssa_traits::{NodeType, SSAMod, SSAWalk};
 use middle::ssa::ssastorage::SSAStorage;
 
 #[derive(Debug)]
-pub struct CSE
-{
+pub struct CSE {
     exprs: HashMap<String, Vec<<SSAStorage as SSA>::ValueRef>>,
     hashed: HashMap<<SSAStorage as SSA>::ValueRef, String>,
 }
@@ -34,8 +36,7 @@ pub const INFO: AnalyzerInfo = AnalyzerInfo {
     uses_policy: true,
 };
 
-impl CSE
-{
+impl CSE {
     pub fn new() -> CSE {
         CSE {
             exprs: HashMap::new(),
@@ -89,16 +90,21 @@ impl CSE
     }
 }
 
-
-impl Analyzer for CSE
-{
-    fn info(&self) -> &'static AnalyzerInfo { &INFO }
-    fn as_any(&self) -> &dyn Any { self }
+impl Analyzer for CSE {
+    fn info(&self) -> &'static AnalyzerInfo {
+        &INFO
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
-impl FuncAnalyzer for CSE
-{
-    fn analyze<T: FnMut(Box<Change>) -> Action>(&mut self, func: &mut RadecoFunction, policy: Option<T>) -> Option<Box<AnalyzerResult>> {
+impl FuncAnalyzer for CSE {
+    fn analyze<T: FnMut(Box<Change>) -> Action>(
+        &mut self,
+        func: &mut RadecoFunction,
+        policy: Option<T>,
+    ) -> Option<Box<AnalyzerResult>> {
         let mut policy = policy.expect("A policy function must be provided");
 
         {
@@ -124,9 +130,9 @@ impl FuncAnalyzer for CSE
                                     ssa.replace_value(expr, *ex_idx);
                                     replaced = true;
                                     break;
-                                },
-                                Action::Skip  => (),
-                                Action::Abort => { return None },
+                                }
+                                Action::Skip => (),
+                                Action::Abort => return None,
                             }
                         }
                     }

--- a/src/analysis/engine.rs
+++ b/src/analysis/engine.rs
@@ -8,14 +8,16 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 use analysis::analyzer;
-use analysis::analyzer::{Action, AnalyzerInfo, AnalyzerKind, Change, FuncAnalyzer, ModuleAnalyzer};
-use analysis::arithmetic::{Arithmetic, ArithChange};
+use analysis::analyzer::{
+    Action, AnalyzerInfo, AnalyzerKind, Change, FuncAnalyzer, ModuleAnalyzer,
+};
+use analysis::arithmetic::{ArithChange, Arithmetic};
 use analysis::copy_propagation::CopyPropagation;
 use analysis::cse::cse::CSE;
 use analysis::cse::ssasort::Sorter;
 use analysis::dce::DCE;
-use analysis::functions::infer_regusage::Inferer;
 use analysis::functions::fix_ssa_opcalls::CallSiteFixer;
+use analysis::functions::infer_regusage::Inferer;
 use analysis::inst_combine::Combiner;
 use analysis::interproc::fixcall::CallFixer;
 use analysis::sccp::SCCP;
@@ -28,11 +30,17 @@ fn sort_by_requires(analyzers: &Vec<AnalyzerKind>) -> impl Iterator<Item = Analy
     let mut kind2id = HashMap::new();
 
     for analyzer in analyzers {
-        let n = kind2id.entry(*analyzer).or_insert_with(|| graph.add_node(*analyzer)).clone();
+        let n = kind2id
+            .entry(*analyzer)
+            .or_insert_with(|| graph.add_node(*analyzer))
+            .clone();
         let info: &'static AnalyzerInfo = From::from(*analyzer);
 
         for dep in info.requires {
-            let d = kind2id.entry(*dep).or_insert_with(|| graph.add_node(*dep)).clone();
+            let d = kind2id
+                .entry(*dep)
+                .or_insert_with(|| graph.add_node(*dep))
+                .clone();
             graph.add_edge(d, n, ());
         }
     }
@@ -42,16 +50,17 @@ fn sort_by_requires(analyzers: &Vec<AnalyzerKind>) -> impl Iterator<Item = Analy
     // property is not garanteed to be respected.
     let sccs = tarjan_scc(&graph);
 
-    sccs.into_iter()
-        .flatten()
-        .map(move |id| graph[id])
-        .rev()
+    sccs.into_iter().flatten().map(move |id| graph[id]).rev()
 }
 
-pub trait EngineResult : Any + Debug { }
+pub trait EngineResult: Any + Debug {}
 
-pub trait Engine : Any + Debug {
-    fn run_module(&self, rmod: &mut RadecoModule, regfile: &SubRegisterFile) -> Option<Box<EngineResult>>;
+pub trait Engine: Any + Debug {
+    fn run_module(
+        &self,
+        rmod: &mut RadecoModule,
+        regfile: &SubRegisterFile,
+    ) -> Option<Box<EngineResult>>;
     fn run_func(&self, rfn: &mut RadecoFunction) -> Option<Box<EngineResult>>;
 }
 
@@ -64,13 +73,17 @@ pub struct RadecoEngine {
 impl RadecoEngine {
     pub fn new(max_iteration: u32) -> Self {
         RadecoEngine {
-            max_iteration: max_iteration
+            max_iteration: max_iteration,
         }
     }
 }
 
 impl Engine for RadecoEngine {
-    fn run_module(&self, rmod: &mut RadecoModule, regfile: &SubRegisterFile) -> Option<Box<EngineResult>> {
+    fn run_module(
+        &self,
+        rmod: &mut RadecoModule,
+        regfile: &SubRegisterFile,
+    ) -> Option<Box<EngineResult>> {
         // Analyze preserved for all functions.
         {
             let bp_name = regfile.get_name_by_alias(&"BP".to_string());
@@ -83,11 +96,11 @@ impl Engine for RadecoEngine {
 
         // Fix call sites
         let mut call_site_fixer = CallSiteFixer::new();
-        call_site_fixer.analyze(rmod, None::<fn(_)->_>);
+        call_site_fixer.analyze(rmod, None::<fn(_) -> _>);
 
         // Infer calling conventions
         let mut inferer = Inferer::new((*regfile).clone());
-        inferer.analyze(rmod, None::<fn(_)->_>);
+        inferer.analyze(rmod, None::<fn(_) -> _>);
 
         for rfn in rmod.functions.values_mut() {
             self.run_func(rfn);
@@ -100,17 +113,20 @@ impl Engine for RadecoEngine {
         // Try to convert the condition codes to relational operators. This should be done before
         // all the other passes.
         let mut arithmetic = Arithmetic::new();
-        arithmetic.analyze(rfn, Some(|change: Box<Change>| {
-            let change = change.as_any().downcast_ref::<ArithChange>().unwrap();
-            if change.new_expr.contains("OpEq") ||
-               change.new_expr.contains("OpGt") ||
-               change.new_expr.contains("OpLt")
-            {
-                Action::Apply
-            } else {
-                Action::Skip
-            }
-        }));
+        arithmetic.analyze(
+            rfn,
+            Some(|change: Box<Change>| {
+                let change = change.as_any().downcast_ref::<ArithChange>().unwrap();
+                if change.new_expr.contains("OpEq")
+                    || change.new_expr.contains("OpGt")
+                    || change.new_expr.contains("OpLt")
+                {
+                    Action::Apply
+                } else {
+                    Action::Skip
+                }
+            }),
+        );
 
         {
             // Sort the IR.
@@ -138,27 +154,27 @@ impl Engine for RadecoEngine {
                     AnalyzerKind::Arithmetic => {
                         let mut arithmetic = Arithmetic::new();
                         arithmetic.analyze(rfn, Some(policy));
-                    },
+                    }
                     AnalyzerKind::Combiner => {
                         let mut combiner = Combiner::new();
                         combiner.analyze(rfn, Some(policy));
-                    },
+                    }
                     AnalyzerKind::CopyPropagation => {
                         let mut copy_propagation = CopyPropagation::new();
                         copy_propagation.analyze(rfn, Some(policy));
-                    },
+                    }
                     AnalyzerKind::CSE => {
                         let mut cse = CSE::new();
                         cse.analyze(rfn, Some(policy));
-                    },
+                    }
                     AnalyzerKind::DCE => {
                         let mut dce = DCE::new();
                         dce.analyze(rfn, Some(policy));
-                    },
+                    }
                     AnalyzerKind::SCCP => {
                         let mut sccp = SCCP::new();
                         sccp.analyze(rfn, Some(policy));
-                    },
+                    }
                     _ => (),
                 }
             }

--- a/src/analysis/functions/fix_ssa_opcalls.rs
+++ b/src/analysis/functions/fix_ssa_opcalls.rs
@@ -7,7 +7,9 @@
 //! [`OpCall`]: ir::MOpcode::OpCall
 //! [the callgraph]: RadecoModule::callgraph
 
-use analysis::analyzer::{Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, ModuleAnalyzer};
+use analysis::analyzer::{
+    Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, ModuleAnalyzer,
+};
 use frontend::radeco_containers::*;
 use middle::ir;
 use middle::ssa::ssa_traits::*;
@@ -36,12 +38,20 @@ impl CallSiteFixer {
 }
 
 impl Analyzer for CallSiteFixer {
-    fn info(&self) -> &'static AnalyzerInfo { &INFO }
-    fn as_any(&self) -> &dyn Any { self }
+    fn info(&self) -> &'static AnalyzerInfo {
+        &INFO
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl ModuleAnalyzer for CallSiteFixer {
-    fn analyze<T: FnMut(Box<Change>) -> Action>(&mut self, rmod: &mut RadecoModule, _policy: Option<T>) -> Option<Box<AnalyzerResult>> {
+    fn analyze<T: FnMut(Box<Change>) -> Action>(
+        &mut self,
+        rmod: &mut RadecoModule,
+        _policy: Option<T>,
+    ) -> Option<Box<AnalyzerResult>> {
         for rfun in rmod.functions.values_mut() {
             go_fn(rfun, &rmod.callgraph);
         }

--- a/src/analysis/functions/infer_regusage.rs
+++ b/src/analysis/functions/infer_regusage.rs
@@ -12,7 +12,10 @@
 //! guarantee that that stack location is never subsequently read or modified.
 //! See #147 for further discussion
 
-use analysis::analyzer::{Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, FuncAnalyzer, ModuleAnalyzer, all};
+use analysis::analyzer::{
+    all, Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, FuncAnalyzer,
+    ModuleAnalyzer,
+};
 use analysis::dce::DCE;
 use analysis::inst_combine::Combiner;
 use frontend::radeco_containers::{RadecoFunction, RadecoModule};
@@ -27,7 +30,6 @@ use petgraph::visit::{DfsPostOrder, Walker};
 
 use std::any::Any;
 use std::collections::{BTreeMap, HashSet};
-
 
 const NAME: &str = "inferer";
 const REQUIRES: &[AnalyzerKind] = &[];
@@ -49,14 +51,22 @@ pub struct Inferer {
 }
 
 impl Analyzer for Inferer {
-    fn info(&self) -> &'static AnalyzerInfo { &INFO }
-    fn as_any(&self) -> &dyn Any { self }
+    fn info(&self) -> &'static AnalyzerInfo {
+        &INFO
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl ModuleAnalyzer for Inferer {
     /// Calls `patch_fn`, `dce::collect`, and `analyze_fn` on every function,
     /// callees first
-    fn analyze<T: FnMut(Box<Change>) -> Action>(&mut self, rmod: &mut RadecoModule, _policy: Option<T>) -> Option<Box<AnalyzerResult>> {
+    fn analyze<T: FnMut(Box<Change>) -> Action>(
+        &mut self,
+        rmod: &mut RadecoModule,
+        _policy: Option<T>,
+    ) -> Option<Box<AnalyzerResult>> {
         // for imports, *ASSUME* that the callconv that r2 says is correct
         let mut new_analyzed = Vec::new();
         {

--- a/src/analysis/inst_combine/combine_rules.rs
+++ b/src/analysis/inst_combine/combine_rules.rs
@@ -39,7 +39,7 @@ macro_rules! gen_rules {
 
 pub(super) fn combine_opinfo(cur_opinfo: &COI, sub_opinfo: &COI) -> Option<COI> {
     // try to keep put the const on the left like `ssasort` does
-    gen_rules!{
+    gen_rules! {
         . -> sub_opinfo -> cur_opinfo
         {
             // add/add

--- a/src/analysis/inst_combine/mod.rs
+++ b/src/analysis/inst_combine/mod.rs
@@ -2,7 +2,9 @@
 //! For every instruction, try to combine one of its operands into itself. This
 //! transforms linear data-dependency chains into trees.
 
-use analysis::analyzer::{Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, FuncAnalyzer};
+use analysis::analyzer::{
+    Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, FuncAnalyzer,
+};
 use frontend::radeco_containers::RadecoFunction;
 use middle::ir::MOpcode;
 use middle::ssa::ssa_traits::*;
@@ -49,7 +51,9 @@ pub struct CombineChange {
 }
 
 impl Change for CombineChange {
-    fn as_any(&self) -> &dyn Any { self }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 enum CombErr {
@@ -97,7 +101,7 @@ impl Combiner {
         &mut self,
         cur_node: SSAValue,
         ssa: &mut SSAStorage,
-        policy: &mut T
+        policy: &mut T,
     ) -> Result<SSAValue, CombErr> {
         // bail if non-combinable
         let extracted = extract_opinfo(cur_node, ssa).ok_or(CombErr::NoComb)?;
@@ -109,7 +113,8 @@ impl Combiner {
                     sub_node,
                     cur_opinfo
                 );
-                let opt_new_node = self.make_combined_node(cur_node, &cur_opinfo, cur_vt, sub_node, ssa, policy);
+                let opt_new_node =
+                    self.make_combined_node(cur_node, &cur_opinfo, cur_vt, sub_node, ssa, policy);
                 match opt_new_node {
                     Ok(Left((new_node, new_sub_node, new_opinfo))) => {
                         radeco_trace!(
@@ -138,7 +143,7 @@ impl Combiner {
                 }
             }
             Right(c_val) => {
-                let action = policy(Box::new(CombineChange{
+                let action = policy(Box::new(CombineChange {
                     node: cur_node,
                     res: Right(c_val),
                 }));
@@ -149,7 +154,7 @@ impl Combiner {
                         radeco_trace!("{:?} = {:#x}", cur_node, c_val);
                         let c_node = ssa.insert_const(c_val, None).ok_or(CombErr::NoComb)?;
                         Ok(c_node)
-                    },
+                    }
                     Action::Skip => Err(CombErr::Skip),
                     Action::Abort => Err(CombErr::Abort),
                 }
@@ -181,7 +186,7 @@ impl Combiner {
         // simplify
         match simplify_opinfo(&new_opinfo) {
             Some(Some(simpl_new_opinfo)) => {
-                let action = policy(Box::new(CombineChange{
+                let action = policy(Box::new(CombineChange {
                     node: cur_node,
                     res: Left((Some(simpl_new_opinfo.clone()), new_sub_node)),
                 }));
@@ -202,10 +207,9 @@ impl Combiner {
                     Action::Skip => Err(CombErr::Skip),
                     Action::Abort => Err(CombErr::Abort),
                 }
-
             }
             Some(None) => {
-                let action = policy(Box::new(CombineChange{
+                let action = policy(Box::new(CombineChange {
                     node: cur_node,
                     res: Left((None, new_sub_node)),
                 }));
@@ -224,7 +228,7 @@ impl Combiner {
                 match new_opinfo {
                     Cow::Borrowed(_) => Err(CombErr::NoComb),
                     Cow::Owned(new_opinfo) => {
-                        let action = policy(Box::new(CombineChange{
+                        let action = policy(Box::new(CombineChange {
                             node: cur_node,
                             res: Left((Some(new_opinfo.clone()), new_sub_node)),
                         }));
@@ -266,12 +270,20 @@ impl Combiner {
 }
 
 impl Analyzer for Combiner {
-    fn info(&self) -> &'static AnalyzerInfo { &INFO }
-    fn as_any(&self) -> &dyn Any { self }
+    fn info(&self) -> &'static AnalyzerInfo {
+        &INFO
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl FuncAnalyzer for Combiner {
-    fn analyze<T: FnMut(Box<Change>) -> Action>(&mut self, func: &mut RadecoFunction, policy: Option<T>) -> Option<Box<AnalyzerResult>> {
+    fn analyze<T: FnMut(Box<Change>) -> Action>(
+        &mut self,
+        func: &mut RadecoFunction,
+        policy: Option<T>,
+    ) -> Option<Box<AnalyzerResult>> {
         let ssa = func.ssa_mut();
         let mut policy = policy.expect("A policy function must be provided");
         for node in ssa.inorder_walk() {

--- a/src/analysis/interproc/digstack.rs
+++ b/src/analysis/interproc/digstack.rs
@@ -279,7 +279,7 @@ mod test {
     use std::fs::File;
     use std::io::prelude::*;
 
-    use analysis::analyzer::{FuncAnalyzer, all};
+    use analysis::analyzer::{all, FuncAnalyzer};
     use analysis::dce::DCE;
     use frontend::radeco_containers::RadecoFunction;
     use frontend::ssaconstructor::SSAConstruct;

--- a/src/analysis/interproc/interproc.rs
+++ b/src/analysis/interproc/interproc.rs
@@ -1,6 +1,8 @@
 //! Fills out the call summary information for `RFunction`
 
-use analysis::analyzer::{Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, ModuleAnalyzer};
+use analysis::analyzer::{
+    Action, Analyzer, AnalyzerInfo, AnalyzerKind, AnalyzerResult, Change, ModuleAnalyzer,
+};
 use analysis::interproc::transfer::InterProcAnalysis;
 use frontend::radeco_containers::RadecoModule;
 
@@ -72,15 +74,23 @@ impl<T: 'static> Analyzer for InterProcAnalyzer<T>
 where
     T: InterProcAnalysis + Debug,
 {
-    fn info(&self) -> &'static AnalyzerInfo { &INFO }
-    fn as_any(&self) -> &dyn Any { self }
+    fn info(&self) -> &'static AnalyzerInfo {
+        &INFO
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl<T: 'static> ModuleAnalyzer for InterProcAnalyzer<T>
 where
     T: InterProcAnalysis + Debug,
 {
-    fn analyze<F: FnMut(Box<Change>) -> Action>(&mut self, rmod: &mut RadecoModule, _policy: Option<F>) -> Option<Box<AnalyzerResult>> {
+    fn analyze<F: FnMut(Box<Change>) -> Action>(
+        &mut self,
+        rmod: &mut RadecoModule,
+        _policy: Option<F>,
+    ) -> Option<Box<AnalyzerResult>> {
         let fs = rmod.functions.clone();
         for (_, f) in fs {
             self.analyze_function(rmod, f.offset);
@@ -93,9 +103,9 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use analysis::analyzer::{FuncAnalyzer, all};
-    use analysis::interproc::summary;
+    use analysis::analyzer::{all, FuncAnalyzer};
     use analysis::dce::DCE;
+    use analysis::interproc::summary;
     use frontend::radeco_containers::ProjectLoader;
     use frontend::radeco_source::FileSource;
     use middle::ir_writer;
@@ -110,7 +120,8 @@ mod test {
         for mut xy in rproj.iter_mut() {
             let mut rmod = &mut xy.module;
             {
-                let mut analyzer: InterProcAnalyzer<summary::CallSummary> = InterProcAnalyzer::new();
+                let mut analyzer: InterProcAnalyzer<summary::CallSummary> =
+                    InterProcAnalyzer::new();
                 analyzer.analyze(&mut rmod, Some(all));
             }
 

--- a/src/analysis/matcher/gmatch.rs
+++ b/src/analysis/matcher/gmatch.rs
@@ -56,7 +56,7 @@ pub struct Match<T: Clone + fmt::Debug> {
 
 impl<T> Match<T>
 where
-    T: Clone + fmt::Debug
+    T: Clone + fmt::Debug,
 {
     pub fn get_root(&self) -> &T {
         &self.root

--- a/src/analysis/reference_marking/reference_marking_inter.rs
+++ b/src/analysis/reference_marking/reference_marking_inter.rs
@@ -115,7 +115,8 @@ impl<T: InterProcAnalysis> InterProceduralAnalyzer<T> {
                     csite_node: csite.csite_node,
                 };
                 (caller, T::pull(&mut current_analyzer, current_fn, &rcsite))
-            }) {
+            })
+        {
             let ref mut e = infos.entry(caller).or_insert(Vec::new());
             if let Some(inf) = info {
                 e.push(inf);
@@ -223,11 +224,9 @@ impl<T: InterProcAnalysis> InterProceduralAnalyzer<T> {
             // dependency.
             for infov in infos.values_mut() {
                 // XXX: Avoid allocation
-                *infov = vec![
-                    infov
-                        .iter()
-                        .fold(T::Info::default(), |acc, x| T::Info::eval(&acc, &x)),
-                ];
+                *infov = vec![infov
+                    .iter()
+                    .fold(T::Info::default(), |acc, x| T::Info::eval(&acc, &x))];
             }
 
             // Push the information down to the analyzers.

--- a/src/analysis/vsa/abstract_set/strided_interval.rs
+++ b/src/analysis/vsa/abstract_set/strided_interval.rs
@@ -30,7 +30,7 @@ use std::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
 use num::bigint::BigInt;
 
 use super::abstract_set::{AbstractSet, Container};
-use super::abstract_set::{_BITS, Inum, Unum};
+use super::abstract_set::{Inum, Unum, _BITS};
 
 // XXX: Distiguish imul/umul idiv/udiv urem/irem
 // XXX: Might fail when k bits is one bit (k == 1)
@@ -180,13 +180,13 @@ where
     //      u = x - x % k_period - k_period = i * k_period
     //      e.g. 4 bits: -1 -> -8, -7 -> -8, -9 -> -16
     // in which i is a stable step function
-    let _x = x.clone() - x.clone() % period.clone() - if (x < T::from(0))
-        && (x.clone() % period.clone() != T::from(0))
-    {
-        period.clone()
-    } else {
-        T::from(0)
-    };
+    let _x = x.clone()
+        - x.clone() % period.clone()
+        - if (x < T::from(0)) && (x.clone() % period.clone() != T::from(0)) {
+            period.clone()
+        } else {
+            T::from(0)
+        };
 
     _x.clone() / period.clone()
 }
@@ -1504,8 +1504,14 @@ mod test {
         assert_eq!(ntz(0x0001000), 12);
         assert_eq!(ntz(0x0), 64);
         assert_eq!(ntz(Inum::min_value()), 63);
-        assert_eq!(min_or(0x0000101, 0x0001001, 0x0010011, 0x0101001), 0x0010101);
-        assert_eq!(max_or(0x0000101, 0x0001001, 0x0010011, 0x0101001), 0x0101fff);
+        assert_eq!(
+            min_or(0x0000101, 0x0001001, 0x0010011, 0x0101001),
+            0x0010101
+        );
+        assert_eq!(
+            max_or(0x0000101, 0x0001001, 0x0010011, 0x0101001),
+            0x0101fff
+        );
         let (x, y) = (3, 8);
         let (s, t) = exgcd(x, y);
         assert_eq!(x * s + y * t, gcd(x, y));

--- a/src/analysis/vsa/mod.rs
+++ b/src/analysis/vsa/mod.rs
@@ -11,8 +11,8 @@
 //!     * https://research.cs.wisc.edu/wpis/papers/balakrishnan_thesis.pdf
 
 pub mod abstract_set {
-    pub mod bdd;
     pub mod abstract_set;
+    pub mod bdd;
     pub mod polynomial;
     pub mod strided_interval;
 }

--- a/src/backend/ctrl_flow_struct/refinement.rs
+++ b/src/backend/ctrl_flow_struct/refinement.rs
@@ -259,11 +259,10 @@ impl<'cd, A: AstContext> Refiner<'cd, A> {
 
                 // can't use `contract_nodes_and_map` b/c we need to know
                 // which node is `then` and which is `else`
-                debug_assert!(
-                    self.graph
-                        .find_edge_undirected(then_node, else_node)
-                        .is_none()
-                );
+                debug_assert!(self
+                    .graph
+                    .find_edge_undirected(then_node, else_node)
+                    .is_none());
                 let preds: NodeSet = self
                     .graph
                     .neighbors_directed(then_node, Incoming)
@@ -496,7 +495,7 @@ impl<'cd, A: AstContext> LoopRefiner<'cd, A> {
         AstNodeC::Loop(LoopType::Endless, Box::new(body))
     }
 
-    gen_rule!{rule_While, |self, body| {
+    gen_rule! {rule_While, |self, body| {
         if let Seq(mut seq) = body {
             if let Some(&Cond(c, box Break, None)) = seq.first() {
                 seq.remove(0);
@@ -509,7 +508,7 @@ impl<'cd, A: AstContext> LoopRefiner<'cd, A> {
         }
     }}
 
-    gen_rule!{rule_DoWhile, |self, body| {
+    gen_rule! {rule_DoWhile, |self, body| {
         if let Seq(mut seq) = body {
             if let Some(&Cond(c, box Break, None)) = seq.last() {
                 seq.pop();
@@ -522,7 +521,7 @@ impl<'cd, A: AstContext> LoopRefiner<'cd, A> {
         }
     }}
 
-    gen_rule!{rule_NestedDoWhile, |self, body| {
+    gen_rule! {rule_NestedDoWhile, |self, body| {
         if let Seq(mut seq) = body {
             if let Some(last) = seq.pop() {
                 if let Cond(c, t, None) = last {
@@ -551,7 +550,7 @@ impl<'cd, A: AstContext> LoopRefiner<'cd, A> {
         }
     }}
 
-    gen_rule!{rule_LoopToSeq, |self, body| {
+    gen_rule! {rule_LoopToSeq, |self, body| {
         if let Seq(mut seq) = body {
             if let Some(last) = seq.pop() {
                 if always_breaks(&last) {
@@ -573,7 +572,7 @@ impl<'cd, A: AstContext> LoopRefiner<'cd, A> {
         }
     }}
 
-    gen_rule!{rule_CondToSeq, |self, body| {
+    gen_rule! {rule_CondToSeq, |self, body| {
         if let Cond(c, t, Some(e)) = body {
             if !contains_break(&*t) && contains_break(&*e) {
                 Ok(self.refine_loop(mk_seq_2(Loop(PreChecked(c), t), *e)))
@@ -585,7 +584,7 @@ impl<'cd, A: AstContext> LoopRefiner<'cd, A> {
         }
     }}
 
-    gen_rule!{rule_CondToSeqNeg, |self, body| {
+    gen_rule! {rule_CondToSeqNeg, |self, body| {
         if let Cond(c, t, Some(e)) = body {
             if contains_break(&*t) && !contains_break(&*e) {
                 Ok(self.refine_loop(mk_seq_2(Loop(PreChecked(self.cctx.mk_not(c)), t), *e)))

--- a/src/backend/lang_c/c_cfg_builder.rs
+++ b/src/backend/lang_c/c_cfg_builder.rs
@@ -671,13 +671,13 @@ impl<'a> CCFGDataMap<'a> {
 mod test {
     use backend::lang_c::c_ast;
     use backend::lang_c::c_cfg;
-    use backend::lang_c::c_cfg_builder::{CCFG, CCFGBuilder, CCFGDataMap, SSARef};
+    use backend::lang_c::c_cfg_builder::{CCFGBuilder, CCFGDataMap, SSARef, CCFG};
     use frontend::radeco_containers::RadecoFunction;
     use frontend::radeco_source::SourceErr;
-    use middle::ir_reader;
     use middle::ir::MOpcode;
+    use middle::ir_reader;
     use middle::regfile::SubRegisterFile;
-    use middle::ssa::ssa_traits::{SSA, SSAWalk};
+    use middle::ssa::ssa_traits::{SSAWalk, SSA};
     use middle::ssa::utils;
     use r2api::structs::LRegInfo;
     use serde_json;
@@ -753,7 +753,8 @@ mod test {
                 return Err("Failed to get dst operand node from CCFG".to_string());
             }
             let assign_node = builder.assign(dst.unwrap(), src.unwrap());
-            let is_err = builder.last_action != assign_node || !builder.cfg.is_assign_node(assign_node);
+            let is_err =
+                builder.last_action != assign_node || !builder.cfg.is_assign_node(assign_node);
             if is_err {
                 Err("Failed to append assign action".to_string())
             } else {
@@ -762,7 +763,10 @@ mod test {
         }
 
         // Verify `call_action` made `CCFG::Action(ActionNode::Call(_))` node.
-        fn verify_call_action_at(builder: &mut CCFGBuilder, call_node: SSARef) -> Result<(), String> {
+        fn verify_call_action_at(
+            builder: &mut CCFGBuilder,
+            call_node: SSARef,
+        ) -> Result<(), String> {
             let call_node = builder.call_action(call_node);
             let is_err = builder.last_action != call_node || !builder.cfg.is_call_node(call_node);
             if is_err {
@@ -956,7 +960,6 @@ mod test {
             }
         }
     }
-
 
     fn register_profile() -> Result<LRegInfo, SourceErr> {
         let regfile_path = "./test_files/x86_register_profile.json";

--- a/src/frontend/ssaconstructor.rs
+++ b/src/frontend/ssaconstructor.rs
@@ -700,27 +700,27 @@ where
             }
 
             /*
-             // Some overrides as we do not support all esil and don't want to panic.
-             let overrides = &["GOTO", "TRAP", "$", "TODO", "REPEAT"];
-             if esil_str.split(",").any(|x| overrides.contains(&x)) {
-                 // Do something else other than asking the parserS
-                 lazy_static! {
-                     static ref OPRE: Regex = Regex::new(r"[[:xdigit:]][[:xdigit:]]")
-                                                 .expect("Unable to compile regex");
-                 }
-            
-                 let byte_str = op.bytes.as_ref().expect("Invalid bytes for instruction");
-                 let bytes = OPRE.captures_iter(byte_str.as_str())
-                     .map(|cap| u8::from_str_radix(&cap[0], 16).expect("Cannot Fail"))
-                     .collect::<Vec<u8>>();
-            
-                 // TODO/XXX:
-                 // This needs to be selected based on the current arch
-                 let ia = X86_CS_IA::new(bytes).expect("Unable to instantiate IA");
-                 self.process_custom(&ia, &mut current_address);
-                 continue;
-             }
-             */
+            // Some overrides as we do not support all esil and don't want to panic.
+            let overrides = &["GOTO", "TRAP", "$", "TODO", "REPEAT"];
+            if esil_str.split(",").any(|x| overrides.contains(&x)) {
+                // Do something else other than asking the parserS
+                lazy_static! {
+                    static ref OPRE: Regex = Regex::new(r"[[:xdigit:]][[:xdigit:]]")
+                                                .expect("Unable to compile regex");
+                }
+
+                let byte_str = op.bytes.as_ref().expect("Invalid bytes for instruction");
+                let bytes = OPRE.captures_iter(byte_str.as_str())
+                    .map(|cap| u8::from_str_radix(&cap[0], 16).expect("Cannot Fail"))
+                    .collect::<Vec<u8>>();
+
+                // TODO/XXX:
+                // This needs to be selected based on the current arch
+                let ia = X86_CS_IA::new(bytes).expect("Unable to instantiate IA");
+                self.process_custom(&ia, &mut current_address);
+                continue;
+            }
+            */
 
             loop {
                 let token_opt = match p.parse::<_, Tokenizer>(esil_str) {
@@ -728,7 +728,7 @@ where
                     Err(_err) => {
                         radeco_err!("{}", _err.to_string());
                         continue;
-                    },
+                    }
                 };
 
                 if let Some(ref token) = token_opt {
@@ -824,110 +824,110 @@ where
     }
 
     /*
-     fn process_custom<IA: InstructionAnalyzer>(&mut self, ia: &IA, addr: &mut MAddress) {
-         let mnemonic = ia.mnemonic().clone();
-         let opcode = MOpcode::OpCustom(mnemonic.into_owned());
-         let vt = ValueInfo::new_unresolved(ir::WidthSpec::Unknown);
-    
-         let custom_opnode = self.phiplacer.add_op(&opcode, addr, vt);
-    
-         let reg_r = ia.registers_read()
-             .iter()
-             .map(|&x| if let &IOperand::Register(ref s) = x {
-                 let tok = Token::ERegister(s.clone());
-                 self.process_in(&Some(tok), addr, None)
-             } else {
-                 None
-             })
-             .filter(|x| x.is_some())
-             .collect::<Vec<_>>();
-    
-         // Use read registers as arguments
-         for (i, reg) in reg_r.iter().enumerate() {
-             if let &Some(ref reg_node) = reg {
-                 self.phiplacer.op_use(&custom_opnode, i as u8, reg_node);
-             }
-         }
-    
-         let opidx = reg_r.len() as u8;
-    
-         let reg_w = ia.registers_written()
-             .iter()
-             .map(|&x| if let &IOperand::Register(ref s) = x {
-                 Some(s)
-             } else {
-                 None
-             })
-             .filter(|x| x.is_some())
-             .collect::<Vec<_>>();
-    
-         // Write out modified variables
-         for reg in &reg_w {
-             if let Some(ref rname) = *reg {
-                 self.phiplacer.write_register(addr, rname, custom_opnode);
-             }
-         }
-    
-         if ia.has_memory_operand() {
-             // <addr> in represented in mem_op, need to extract the mib.
-             // base + index*scale +- disp
-             let (opcode, maddr) = if let Some(mem_op) = ia.memory_written() {
-                 // Insert a store
-                 let st = MOpcode::OpStore;
-                 let addr =
-                     if let &IOperand::Memory { ref base, ref index, ref scale, ref disp } =
-                         mem_op {
-                         self.process_memory_op(base, index, *scale, *disp, addr)
-                     } else {
-                         unreachable!()
-                     };
-                 (st, addr)
-             } else if let Some(mem_op) = ia.memory_read() {
-                 // Insert load
-                 let ld = MOpcode::OpLoad;
-                 let addr =
-                     if let &IOperand::Memory { ref base, ref index, ref scale, ref disp } =
-                         mem_op {
-                         self.process_memory_op(base, index, *scale, *disp, addr)
-                     } else {
-                         unreachable!()
-                     };
-                 (ld, addr)
-             } else {
-                 // Memory has to be a load or a store operation, cannot be anything else
-                 unreachable!()
-             };
-    
-             let mem_op = self.phiplacer.add_op(&opcode, addr, vt);
-             let mem = self.phiplacer.read_variable(addr, self.mem_id);
-    
-             // Op[Load/Store](mem, addr)
-             self.phiplacer.op_use(&mem_op, 0, &mem);
-             self.phiplacer.op_use(&mem_op, 1, &maddr);
-    
-             // Do some additional handling, such as associating the written value,
-             // creating new instance of memory etc.
-             if opcode == MOpcode::OpStore {
-                 self.phiplacer.op_use(&mem_op, 2, &custom_opnode);
-                 // New instance of memory
-                 self.phiplacer.write_variable(*addr, self.mem_id, mem_op);
-             } else {
-                 // Use memory load in the custom_opnode
-                 self.phiplacer.op_use(&custom_opnode, opidx, &mem_op);
-             }
-         }
-     }
-     */
+    fn process_custom<IA: InstructionAnalyzer>(&mut self, ia: &IA, addr: &mut MAddress) {
+        let mnemonic = ia.mnemonic().clone();
+        let opcode = MOpcode::OpCustom(mnemonic.into_owned());
+        let vt = ValueInfo::new_unresolved(ir::WidthSpec::Unknown);
+
+        let custom_opnode = self.phiplacer.add_op(&opcode, addr, vt);
+
+        let reg_r = ia.registers_read()
+            .iter()
+            .map(|&x| if let &IOperand::Register(ref s) = x {
+                let tok = Token::ERegister(s.clone());
+                self.process_in(&Some(tok), addr, None)
+            } else {
+                None
+            })
+            .filter(|x| x.is_some())
+            .collect::<Vec<_>>();
+
+        // Use read registers as arguments
+        for (i, reg) in reg_r.iter().enumerate() {
+            if let &Some(ref reg_node) = reg {
+                self.phiplacer.op_use(&custom_opnode, i as u8, reg_node);
+            }
+        }
+
+        let opidx = reg_r.len() as u8;
+
+        let reg_w = ia.registers_written()
+            .iter()
+            .map(|&x| if let &IOperand::Register(ref s) = x {
+                Some(s)
+            } else {
+                None
+            })
+            .filter(|x| x.is_some())
+            .collect::<Vec<_>>();
+
+        // Write out modified variables
+        for reg in &reg_w {
+            if let Some(ref rname) = *reg {
+                self.phiplacer.write_register(addr, rname, custom_opnode);
+            }
+        }
+
+        if ia.has_memory_operand() {
+            // <addr> in represented in mem_op, need to extract the mib.
+            // base + index*scale +- disp
+            let (opcode, maddr) = if let Some(mem_op) = ia.memory_written() {
+                // Insert a store
+                let st = MOpcode::OpStore;
+                let addr =
+                    if let &IOperand::Memory { ref base, ref index, ref scale, ref disp } =
+                        mem_op {
+                        self.process_memory_op(base, index, *scale, *disp, addr)
+                    } else {
+                        unreachable!()
+                    };
+                (st, addr)
+            } else if let Some(mem_op) = ia.memory_read() {
+                // Insert load
+                let ld = MOpcode::OpLoad;
+                let addr =
+                    if let &IOperand::Memory { ref base, ref index, ref scale, ref disp } =
+                        mem_op {
+                        self.process_memory_op(base, index, *scale, *disp, addr)
+                    } else {
+                        unreachable!()
+                    };
+                (ld, addr)
+            } else {
+                // Memory has to be a load or a store operation, cannot be anything else
+                unreachable!()
+            };
+
+            let mem_op = self.phiplacer.add_op(&opcode, addr, vt);
+            let mem = self.phiplacer.read_variable(addr, self.mem_id);
+
+            // Op[Load/Store](mem, addr)
+            self.phiplacer.op_use(&mem_op, 0, &mem);
+            self.phiplacer.op_use(&mem_op, 1, &maddr);
+
+            // Do some additional handling, such as associating the written value,
+            // creating new instance of memory etc.
+            if opcode == MOpcode::OpStore {
+                self.phiplacer.op_use(&mem_op, 2, &custom_opnode);
+                // New instance of memory
+                self.phiplacer.write_variable(*addr, self.mem_id, mem_op);
+            } else {
+                // Use memory load in the custom_opnode
+                self.phiplacer.op_use(&custom_opnode, opidx, &mem_op);
+            }
+        }
+    }
+    */
 } // end impl SSAConstruct
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use analysis::analyzer::{FuncAnalyzer, all};
-    use analysis::sccp::SCCP;
+    use analysis::analyzer::{all, FuncAnalyzer};
     use analysis::dce::DCE;
-    use middle::ir_writer;
+    use analysis::sccp::SCCP;
     use middle::dot;
+    use middle::ir_writer;
     use r2api::structs::{LFunctionInfo, LRegInfo};
     use serde_json;
     use std::fs::File;

--- a/src/middle/mod.rs
+++ b/src/middle/mod.rs
@@ -9,20 +9,25 @@
 
 #[macro_use]
 pub mod ssa {
-    pub mod graph_traits;
     pub mod cfg_traits;
-    #[macro_use] pub mod ssa_traits;
-    pub mod ssastorage;
+    pub mod graph_traits;
+    #[macro_use]
+    pub mod ssa_traits;
     pub mod error;
-    pub mod ssadot;
     pub mod memoryssa;
-    #[allow(non_snake_case)] pub mod verifier;
+    pub mod ssadot;
+    pub mod ssastorage;
     pub mod utils;
+    #[allow(non_snake_case)]
+    pub mod verifier;
 }
 
-#[macro_use] pub mod dot;
+#[macro_use]
+pub mod dot;
 pub mod ir;
 pub mod ir_reader;
-#[macro_use] pub mod ir_writer;
-#[allow(non_snake_case)] pub mod phiplacement;
+#[macro_use]
+pub mod ir_writer;
+#[allow(non_snake_case)]
+pub mod phiplacement;
 pub mod regfile;

--- a/src/middle/regfile/mod.rs
+++ b/src/middle/regfile/mod.rs
@@ -157,7 +157,9 @@ impl SubRegisterFile {
 
     // Get id for a register named `reg`
     pub fn register_id_by_name(&self, reg: &str) -> Option<RegisterId> {
-        self.named_registers.get(reg).map(|sr| RegisterId::from_usize(sr.base as usize))
+        self.named_registers
+            .get(reg)
+            .map(|sr| RegisterId::from_usize(sr.base as usize))
     }
 
     // Get id for register by alias/role

--- a/src/middle/regfile/regmap.rs
+++ b/src/middle/regfile/regmap.rs
@@ -11,9 +11,9 @@ pub struct RegisterMap<V> {
 }
 
 impl<V> RegisterMap<V> {
-    pub(super) fn with_register_count(regcount: usize ) -> Self {
+    pub(super) fn with_register_count(regcount: usize) -> Self {
         RegisterMap {
-            map: VecMap::with_capacity(regcount)
+            map: VecMap::with_capacity(regcount),
         }
     }
     pub fn get(&self, key: RegisterId) -> Option<&V> {
@@ -23,7 +23,11 @@ impl<V> RegisterMap<V> {
         self.map.get_mut(key.to_usize())
     }
     pub fn insert(&mut self, key: RegisterId, value: V) -> Option<V> {
-        assert!(key.to_usize() < self.map.capacity(), "invalid regid: {:?}", key);
+        assert!(
+            key.to_usize() < self.map.capacity(),
+            "invalid regid: {:?}",
+            key
+        );
         self.map.insert(key.to_usize(), value)
     }
     pub fn remove(&mut self, key: RegisterId) -> Option<V> {

--- a/src/middle/ssa/cfg_traits.rs
+++ b/src/middle/ssa/cfg_traits.rs
@@ -40,8 +40,8 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 
+use super::graph_traits::{ConditionInfo, Graph};
 use middle::ir::MAddress;
-use super::graph_traits::{Graph, ConditionInfo};
 
 /// Provides __accessors__ to the underlying storage
 pub trait CFG: Graph {
@@ -121,7 +121,12 @@ pub trait CFGMod: CFG {
     fn insert_dynamic(&mut self) -> Option<Self::ActionRef>;
 
     /// Insert a control edge between to basic blocks
-    fn insert_control_edge(&mut self, source: Self::ActionRef, target: Self::ActionRef, index: u8) -> Option<Self::CFEdgeRef>;
+    fn insert_control_edge(
+        &mut self,
+        source: Self::ActionRef,
+        target: Self::ActionRef,
+        index: u8,
+    ) -> Option<Self::CFEdgeRef>;
 
     /// Remove a block and all its associated data from the graph
     fn remove_block(&mut self, node: Self::ActionRef);

--- a/src/middle/ssa/error.rs
+++ b/src/middle/ssa/error.rs
@@ -5,10 +5,10 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{error, fmt};
 use super::ssa_traits::SSA;
 use super::ssastorage::SSAStorage;
 use std::fmt::Debug;
+use std::{error, fmt};
 
 #[derive(Debug)]
 pub enum SSAErr<T: SSA + Debug> {
@@ -33,57 +33,40 @@ pub enum SSAErr<T: SSA + Debug> {
 impl fmt::Display for SSAErr<SSAStorage> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let err = match *self {
-            SSAErr::InvalidBlock(ni) => {
-                format!("Found Block with index: {:?}.", ni)
-            }
-            SSAErr::InvalidType(ref e) => {
-                format!("Expected type: {}.", e)
-            }
+            SSAErr::InvalidBlock(ni) => format!("Found Block with index: {:?}.", ni),
+            SSAErr::InvalidType(ref e) => format!("Expected type: {}.", e),
             SSAErr::InvalidControl(bi, ei) => {
                 format!("Block {:?} has invalid outgoing edge: {:?}", bi, ei)
             }
             SSAErr::WrongNumOperands(n, e, f) => {
                 format!("{:?} expected {} number of operands, found: {}", n, e, f)
             }
-            SSAErr::InvalidTarget(bi, ei, ti) => {
-                format!("Block {:?} has Edge {:?} with invalid target {:?}",
-                        bi,
-                        ei,
-                        ti)
-            }
+            SSAErr::InvalidTarget(bi, ei, ti) => format!(
+                "Block {:?} has Edge {:?} with invalid target {:?}",
+                bi, ei, ti
+            ),
             SSAErr::WrongNumEdges(ni, e, f) => {
                 format!("Block {:?} expects {} edge(s), found: {}", ni, e, f)
             }
-            SSAErr::NoSelector(bi) => {
-                format!("Block {:?} expects a selector. None found.", bi)
-            }
+            SSAErr::NoSelector(bi) => format!("Block {:?} expects a selector. None found.", bi),
             SSAErr::UnexpectedSelector(bi, ni) => {
                 format!("Block {:?} expected no selector, found: {:?}", bi, ni)
             }
-            SSAErr::UnreachableBlock(bi) => {
-                format!("Unreachable block found: {:?}", bi)
-            }
-            SSAErr::InvalidExpr(ni) => {
-                format!("Found an invalid expression: {:?}", ni)
-            }
+            SSAErr::UnreachableBlock(bi) => format!("Unreachable block found: {:?}", bi),
+            SSAErr::InvalidExpr(ni) => format!("Found an invalid expression: {:?}", ni),
             SSAErr::IncompatibleWidth(ni, e, f) => {
                 format!("{:?} expected with to be {}, found width: {}", ni, e, f)
             }
-            SSAErr::BackUse(ref i, ref j) => {
-                format!("Found back use from {:?} to {:?}", i, j)
-            }
+            SSAErr::BackUse(ref i, ref j) => format!("Found back use from {:?} to {:?}", i, j),
             SSAErr::UnreachablePhiSCC(ref nodes) => {
                 format!("Found Use-Def chains become a loop: {:?}", nodes)
             }
-            SSAErr::UnrecordedConstant(con) => {
-                format!("Found unrecored constant: {:#}", con)
-            }
-            SSAErr::MultiConstantCopy(con, ref i, ref j) => {
-                format!("Found more than one copy of {:#}, with {:?} an {:?}", con, i, j)
-            }
-            SSAErr::Other(s) => {
-                format!("{}", s)
-            }
+            SSAErr::UnrecordedConstant(con) => format!("Found unrecored constant: {:#}", con),
+            SSAErr::MultiConstantCopy(con, ref i, ref j) => format!(
+                "Found more than one copy of {:#}, with {:?} an {:?}",
+                con, i, j
+            ),
+            SSAErr::Other(s) => format!("{}", s),
         };
         write!(f, "{}.", err)
     }

--- a/src/middle/ssa/graph_traits.rs
+++ b/src/middle/ssa/graph_traits.rs
@@ -18,10 +18,10 @@
 //!  Basic Graph Operation.
 //!
 //!  The above traits are generic over indexes that are used to refer to edges
-//!  and nodes in a graph. 
+//!  and nodes in a graph.
 //!
-//!  It is important to note that the trait `SSA` and `CFG` require `Graph` to 
-//!  be implemented. 
+//!  It is important to note that the trait `SSA` and `CFG` require `Graph` to
+//!  be implemented.
 //!
 //!  Individual traits and their methods are explained in their respective
 //!  docs.
@@ -33,7 +33,6 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use petgraph::EdgeDirection;
-
 
 // TODO: Add invalid function for EdgeInfo and ConditionInfo
 
@@ -67,7 +66,7 @@ impl<T: Eq + Hash + Clone + Copy + Debug> ConditionInfo<T> {
             false_side: false_side,
         }
     }
-} 
+}
 
 /// Trait provide basic graph operations.
 pub trait Graph {
@@ -99,17 +98,36 @@ pub trait Graph {
     fn replace_node(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef);
 
     /// Insert a new edge into graph.
-    fn insert_edge(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef, e: Self::EdgeData) -> Option<Self::GraphEdgeRef>; 
+    fn insert_edge(
+        &mut self,
+        i: Self::GraphNodeRef,
+        j: Self::GraphNodeRef,
+        e: Self::EdgeData,
+    ) -> Option<Self::GraphEdgeRef>;
 
     /// Update edge information.
-    fn update_edge(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef, e: Self::EdgeData) -> Option<Self::GraphEdgeRef>;
+    fn update_edge(
+        &mut self,
+        i: Self::GraphNodeRef,
+        j: Self::GraphNodeRef,
+        e: Self::EdgeData,
+    ) -> Option<Self::GraphEdgeRef>;
 
     /// Reference to the edge that connects the source to the target.
-    fn find_edges_between(&self, source: Self::GraphNodeRef, target: Self::GraphNodeRef) -> Vec<Self::GraphEdgeRef>;
+    fn find_edges_between(
+        &self,
+        source: Self::GraphNodeRef,
+        target: Self::GraphNodeRef,
+    ) -> Vec<Self::GraphEdgeRef>;
 
     /// Remove edges beteween nodes.
-    fn remove_edges_between(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef); 
+    fn remove_edges_between(&mut self, i: Self::GraphNodeRef, j: Self::GraphNodeRef);
 
     /// Gather neighborhood nodes.
-    fn gather_adjacences(&self, node: Self::GraphNodeRef, direction: EdgeDirection, data: bool) -> Vec<Self::GraphNodeRef>;
+    fn gather_adjacences(
+        &self,
+        node: Self::GraphNodeRef,
+        direction: EdgeDirection,
+        data: bool,
+    ) -> Vec<Self::GraphNodeRef>;
 }

--- a/src/middle/ssa/utils.rs
+++ b/src/middle/ssa/utils.rs
@@ -49,7 +49,10 @@ pub fn call_rets(call_node: NodeIndex, ssa: &SSAStorage) -> RegisterMap<(NodeInd
 }
 
 /// Extracts the value of all registers at a `RegisterState` SSA node.
-pub fn register_state_info(regstate_node: NodeIndex, ssa: &SSAStorage) -> RegisterMap<(NodeIndex, ValueInfo)> {
+pub fn register_state_info(
+    regstate_node: NodeIndex,
+    ssa: &SSAStorage,
+) -> RegisterMap<(NodeIndex, ValueInfo)> {
     let mut ret = ssa.regfile.new_register_map();
     for edge_ref in ssa.g.edges_directed(regstate_node, Outgoing) {
         if let (&EdgeData::Data(op_idx), Some(&vt)) =

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -43,39 +43,18 @@ pub enum Event<'a, T: 'a + Debug> {
 impl<'a, T: Debug> ToString for Event<'a, T> {
     fn to_string(&self) -> String {
         match *self {
-            Event::SSAInsertNode(i) => {
-                format!("{}|{:?}", "ssa_insert_node", i)
-            }
-            Event::SSARemoveNode(i) => {
-                format!("{}|{:?}", "ssa_remove_node", i)
-            }
-            Event::SSAReplaceNode(i, j) => {
-                format!("{}|{:?}|{:?}", "ssa_replace", i, j)
-            }
-            Event::SSAInsertEdge(i, j) => {
-                format!("{}|{:?}|{:?}", "ssa_insert_edge", i, j)
-            }
-            Event::SSARemoveEdge(i, j) => {
-                format!("{}|{:?}|{:?}", "ssa_remove_edge", i, j)
-            }
-            Event::SSAUpdateEdge(i, j) => {
-                format!("{}|{:?}|{:?}", "ssa_update_edge", i, j)
-            }
-            Event::SSAMarkNode(i) => {
-                format!("{}|{:?}", "ssa_mark_node", i)
-            }
-            Event::SSAClearMark(i) => {
-                format!("{}|{:?}", "ssa_clear_mark", i)
-            }
-            Event::SSAQueryExternal(i) => {
-                format!("{}|{:?}", "ssa_query_external", i)
-            }
-            Event::SSAQueryInternal(i) => {
-                format!("{}|{:?}", "ssa_query_internal", i)
-            }
+            Event::SSAInsertNode(i) => format!("{}|{:?}", "ssa_insert_node", i),
+            Event::SSARemoveNode(i) => format!("{}|{:?}", "ssa_remove_node", i),
+            Event::SSAReplaceNode(i, j) => format!("{}|{:?}|{:?}", "ssa_replace", i, j),
+            Event::SSAInsertEdge(i, j) => format!("{}|{:?}|{:?}", "ssa_insert_edge", i, j),
+            Event::SSARemoveEdge(i, j) => format!("{}|{:?}|{:?}", "ssa_remove_edge", i, j),
+            Event::SSAUpdateEdge(i, j) => format!("{}|{:?}|{:?}", "ssa_update_edge", i, j),
+            Event::SSAMarkNode(i) => format!("{}|{:?}", "ssa_mark_node", i),
+            Event::SSAClearMark(i) => format!("{}|{:?}", "ssa_clear_mark", i),
+            Event::SSAQueryExternal(i) => format!("{}|{:?}", "ssa_query_external", i),
+            Event::SSAQueryInternal(i) => format!("{}|{:?}", "ssa_query_internal", i),
         }
     }
-
 }
 
 #[macro_export]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -31,385 +31,384 @@ pub mod logger;
 //use middle::ssa::verifier;
 
 //macro_rules! out {
-    //($str: expr, $m: expr) => { if $m { println!($str) } }
+//($str: expr, $m: expr) => { if $m { println!($str) } }
 //}
 
 //#[derive(Clone, Copy, Debug)]
 //pub enum Analysis {
-    //ConstProp,
+//ConstProp,
 //}
 
 //#[derive(Clone, Copy, Debug)]
 //pub enum Pipeline {
-    //ReadFromR2,
-    //ParseEsil,
-    //CFG,
-    //SSA,
-    //AnalyzeSSA(Analysis),
-    //DCE,
-    //Verify,
-    //CWriter,
+//ReadFromR2,
+//ParseEsil,
+//CFG,
+//SSA,
+//AnalyzeSSA(Analysis),
+//DCE,
+//Verify,
+//CWriter,
 //}
 
 //// Enum that represents the output of a stage in the Pipeline.
 //// Every stage has a corresponding Pipeout type.
 //#[derive(Clone)]
 //pub enum Pipeout {
-    //Esil(Vec<String>),
-    //LOpInfo(Vec<LOpInfo>),
-    //Instructions {
-        //i: Vec<MInst>,
-    //},
-    //CFG {
-        //cfg: CFG,
-    //},
-    //SSA {
-        //ssa: SSAStorage,
-    //},
+//Esil(Vec<String>),
+//LOpInfo(Vec<LOpInfo>),
+//Instructions {
+//i: Vec<MInst>,
+//},
+//CFG {
+//cfg: CFG,
+//},
+//SSA {
+//ssa: SSAStorage,
+//},
 //}
 
 //impl Pipeout {
-    //fn to_string(&self) -> String {
-        //let s = match *self {
-            //Pipeout::Esil(_) => "esil",
-            //Pipeout::LOpInfo(_) => "esil",
-            //Pipeout::Instructions {i: _} => "ir",
-            //Pipeout::CFG {cfg: _} => "cfg",
-            //Pipeout::SSA {ssa: _} => "ssa",
-        //};
-        //s.to_string()
-    //}
+//fn to_string(&self) -> String {
+//let s = match *self {
+//Pipeout::Esil(_) => "esil",
+//Pipeout::LOpInfo(_) => "esil",
+//Pipeout::Instructions {i: _} => "ir",
+//Pipeout::CFG {cfg: _} => "cfg",
+//Pipeout::SSA {ssa: _} => "ssa",
+//};
+//s.to_string()
+//}
 //}
 
 //// States all the vars important to various stages of the pipeline together.
 //// Also acts as the result struct.
 //#[allow(dead_code)]
 //pub struct State {
-    //r2: Option<R2>,
-    //esil: Option<Vec<String>>,
-    //pub reg_info: Option<LRegInfo>,
-    //p: Option<Parser>,
-    //cfg: Option<CFG>,
-    //ssa: Option<SSAStorage>,
-    //pub pipeout: Option<Pipeout>,
+//r2: Option<R2>,
+//esil: Option<Vec<String>>,
+//pub reg_info: Option<LRegInfo>,
+//p: Option<Parser>,
+//cfg: Option<CFG>,
+//ssa: Option<SSAStorage>,
+//pub pipeout: Option<Pipeout>,
 //}
 
 //impl State {
-    //fn new() -> State {
-        //State {
-            //r2: None,
-            //esil: None,
-            //reg_info: None,
-            //p: None,
-            //cfg: None,
-            //ssa: None,
-            //pipeout: None,
-        //}
-    //}
+//fn new() -> State {
+//State {
+//r2: None,
+//esil: None,
+//reg_info: None,
+//p: None,
+//cfg: None,
+//ssa: None,
+//pipeout: None,
+//}
+//}
 //}
 
 //pub struct Runner {
-    //name: String,
-    //bin_name: Option<String>,
-    //addr: Option<String>,
-    //verbose: bool,
-    //pipeline: Vec<Pipeline>,
-    //results: Vec<Pipeout>,
-    //outpath: String,
-    //pub state: State,
+//name: String,
+//bin_name: Option<String>,
+//addr: Option<String>,
+//verbose: bool,
+//pipeline: Vec<Pipeline>,
+//results: Vec<Pipeout>,
+//outpath: String,
+//pub state: State,
 //}
 
 //impl fmt::Display for Pipeline {
-    //fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        //match *self {
-            //Pipeline::ReadFromR2 => write!(f, "{}", "r2"),
-            //Pipeline::ParseEsil => write!(f, "{}", "Parse ESIL"),
-            //Pipeline::CFG => write!(f, "{}", "Control Flow Graph Construction"),
-            //Pipeline::SSA => write!(f, "{}", "SSA Construction"),
-            //Pipeline::AnalyzeSSA(_) => write!(f, "{}", "Constant Propagation"),
-            //Pipeline::DCE => write!(f, "{}", "Dead Code Elimination"),
-            //Pipeline::Verify => write!(f, "{}", "Verify SSA"),
-            //Pipeline::CWriter => write!(f, "{}", "C Writer"),
-        //}
-    //}
+//fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//match *self {
+//Pipeline::ReadFromR2 => write!(f, "{}", "r2"),
+//Pipeline::ParseEsil => write!(f, "{}", "Parse ESIL"),
+//Pipeline::CFG => write!(f, "{}", "Control Flow Graph Construction"),
+//Pipeline::SSA => write!(f, "{}", "SSA Construction"),
+//Pipeline::AnalyzeSSA(_) => write!(f, "{}", "Constant Propagation"),
+//Pipeline::DCE => write!(f, "{}", "Dead Code Elimination"),
+//Pipeline::Verify => write!(f, "{}", "Verify SSA"),
+//Pipeline::CWriter => write!(f, "{}", "C Writer"),
+//}
+//}
 //}
 
 //impl fmt::Display for Runner {
-    //fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        //let mut res;
-        //res = format!("Name: {}\n", self.name);
-        //res = format!("{}Binary: {}\n",
-                      //res,
-                      //self.bin_name.as_ref().unwrap_or(&"-".to_owned()));
-        //res = format!("{}Address: {}\n",
-                      //res,
-                      //self.addr.as_ref().unwrap_or(&"-".to_owned()));
-        //res = format!("{}Pipeline:\n", res);
-        //for p in &self.pipeline {
-            //res = format!("{}    - {}\n", res, p);
-        //}
-        //res = format!("{}Output: {}", res, self.outpath);
-        //write!(f, "{}", res)
-    //}
+//fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//let mut res;
+//res = format!("Name: {}\n", self.name);
+//res = format!("{}Binary: {}\n",
+//res,
+//self.bin_name.as_ref().unwrap_or(&"-".to_owned()));
+//res = format!("{}Address: {}\n",
+//res,
+//self.addr.as_ref().unwrap_or(&"-".to_owned()));
+//res = format!("{}Pipeline:\n", res);
+//for p in &self.pipeline {
+//res = format!("{}    - {}\n", res, p);
 //}
-
+//res = format!("{}Output: {}", res, self.outpath);
+//write!(f, "{}", res)
+//}
+//}
 
 //impl Runner {
 
-    //pub fn new(name: String,
-               //bin_name: Option<String>,
-               //addr: Option<String>,
-               //verbose: bool,
-               //pipeline: Vec<Pipeline>,
-               //outpath: Option<String>)
-               //-> Runner {
-        //Runner {
-            //name: name,
-            //bin_name: bin_name,
-            //addr: addr,
-            //verbose: verbose,
-            //pipeline: pipeline,
-            //results: Vec::new(),
-            //state: State::new(),
-            //outpath: outpath.unwrap_or("./outputs".to_owned()),
-        //}
-    //}
+//pub fn new(name: String,
+//bin_name: Option<String>,
+//addr: Option<String>,
+//verbose: bool,
+//pipeline: Vec<Pipeline>,
+//outpath: Option<String>)
+//-> Runner {
+//Runner {
+//name: name,
+//bin_name: bin_name,
+//addr: addr,
+//verbose: verbose,
+//pipeline: pipeline,
+//results: Vec::new(),
+//state: State::new(),
+//outpath: outpath.unwrap_or("./outputs".to_owned()),
+//}
+//}
 
-    //pub fn is_verbose(&self) -> bool {
-        //self.verbose
-    //}
+//pub fn is_verbose(&self) -> bool {
+//self.verbose
+//}
 
-    //fn set_reg_info(&mut self, reg_info: &LRegInfo) {
-        //self.state.reg_info = Some(reg_info.clone());
-    //}
+//fn set_reg_info(&mut self, reg_info: &LRegInfo) {
+//self.state.reg_info = Some(reg_info.clone());
+//}
 
-    //fn set_pipeout(&mut self, pipeout: &Pipeout) {
-        //self.state.pipeout = Some(pipeout.clone());
-    //}
+//fn set_pipeout(&mut self, pipeout: &Pipeout) {
+//self.state.pipeout = Some(pipeout.clone());
+//}
 
-    //fn read_from_r2(&mut self) {
-        //// assert!(!self.bin_name.is_none());
-        //// assert!(!self.addr.is_none());
-        //out!("[*] Reading from R2", self.verbose);
+//fn read_from_r2(&mut self) {
+//// assert!(!self.bin_name.is_none());
+//// assert!(!self.addr.is_none());
+//out!("[*] Reading from R2", self.verbose);
 
-        //if self.state.r2.is_none() {
-            //let bin_name = self.bin_name.clone();
-            //// TODO: Error Handling
-            //let mut _r2 = R2::new(bin_name).unwrap();
-            //_r2.init();
-            //self.state.r2 = Some(_r2);
-        //}
-        //let func_info;
-        //let reg_info;
-        //match self.state.r2.as_mut() {
-            //Some(r2) => {
-                //reg_info = r2.get_reg_info().unwrap();
-                //let addr = self.addr.clone().unwrap();
-                //func_info = r2.get_function(&*addr).unwrap();
-            //}
-            //None => panic!("Unable to Initialize r2. Something is wrong!"),
-        //}
+//if self.state.r2.is_none() {
+//let bin_name = self.bin_name.clone();
+//// TODO: Error Handling
+//let mut _r2 = R2::new(bin_name).unwrap();
+//_r2.init();
+//self.state.r2 = Some(_r2);
+//}
+//let func_info;
+//let reg_info;
+//match self.state.r2.as_mut() {
+//Some(r2) => {
+//reg_info = r2.get_reg_info().unwrap();
+//let addr = self.addr.clone().unwrap();
+//func_info = r2.get_function(&*addr).unwrap();
+//}
+//None => panic!("Unable to Initialize r2. Something is wrong!"),
+//}
 
-        //self.set_reg_info(&reg_info);
-        //self.set_pipeout(&Pipeout::LOpInfo(func_info.ops.unwrap()));
-    //}
+//self.set_reg_info(&reg_info);
+//self.set_pipeout(&Pipeout::LOpInfo(func_info.ops.unwrap()));
+//}
 
-    //fn parse_esil(&mut self) {
-        //let pipein = self.state.pipeout.clone().unwrap();
-        //out!("[*] Parsing ESIL", self.verbose);
-        //let mut p = Parser::new(None);
-        //if let Some(ref r) = self.state.reg_info {
-            //p.set_register_profile(r);
-        //}
-        //match pipein {
-            //Pipeout::Esil(strs) => {
-                //for _str in strs {
-                    //p.parse_str(&*_str).ok();
-                //}
-            //}
-            //Pipeout::LOpInfo(mut ops) => {
-                //for op in ops.iter_mut() {
-                    //p.parse_opinfo(op).ok();
-                //}
-            //}
-            //_ => panic!("Incompatible type found in the pipeline!"),
-        //}
+//fn parse_esil(&mut self) {
+//let pipein = self.state.pipeout.clone().unwrap();
+//out!("[*] Parsing ESIL", self.verbose);
+//let mut p = Parser::new(None);
+//if let Some(ref r) = self.state.reg_info {
+//p.set_register_profile(r);
+//}
+//match pipein {
+//Pipeout::Esil(strs) => {
+//for _str in strs {
+//p.parse_str(&*_str).ok();
+//}
+//}
+//Pipeout::LOpInfo(mut ops) => {
+//for op in ops.iter_mut() {
+//p.parse_opinfo(op).ok();
+//}
+//}
+//_ => panic!("Incompatible type found in the pipeline!"),
+//}
 
-        //let insts = p.emit_insts();
-        //let pipeout = Pipeout::Instructions { i: insts };
-        //self.set_pipeout(&pipeout);
-        //self.state.p = Some(p);
-    //}
+//let insts = p.emit_insts();
+//let pipeout = Pipeout::Instructions { i: insts };
+//self.set_pipeout(&pipeout);
+//self.state.p = Some(p);
+//}
 
-    //fn construct_cfg(&mut self) {
-        //let mut pipein = self.state.pipeout.clone().unwrap();
-        //out!("[*] Starting CFG Construction", self.verbose);
-        //match pipein {
-            //Pipeout::Instructions {i: ref mut insts} => {
-                //let mut cfg = CFG::new();
-                //cfg.build(insts);
-                //let pipeout = Pipeout::CFG { cfg: cfg.clone() };
-                //self.set_pipeout(&pipeout);
-                //self.state.cfg = Some(cfg);
-            //}
-            //_ => panic!("Incompatible type found in the pipeline!"),
-        //}
-    //}
+//fn construct_cfg(&mut self) {
+//let mut pipein = self.state.pipeout.clone().unwrap();
+//out!("[*] Starting CFG Construction", self.verbose);
+//match pipein {
+//Pipeout::Instructions {i: ref mut insts} => {
+//let mut cfg = CFG::new();
+//cfg.build(insts);
+//let pipeout = Pipeout::CFG { cfg: cfg.clone() };
+//self.set_pipeout(&pipeout);
+//self.state.cfg = Some(cfg);
+//}
+//_ => panic!("Incompatible type found in the pipeline!"),
+//}
+//}
 
-    //fn construct_ssa(&mut self) {
-        //// TODO: Relax this condition.
-        //assert!(self.state.reg_info.is_some());
-        //out!("[*] Starting SSA Construction", self.verbose);
-        //let pipein = self.state.pipeout.clone().unwrap();
-        //let r = self.state.reg_info.clone().unwrap();
-        //match pipein {
-            //Pipeout::CFG {ref cfg} => {
-                //let mut ssa = SSAStorage::new();
-                //{
-                    ////let mut con = SSAConstruction::new(&mut ssa, &r);
-                    ////con.run(cfg);
-                //}
-                //let pipeout = Pipeout::SSA { ssa: ssa.clone() };
-                //self.set_pipeout(&pipeout);
-                //self.state.ssa = Some(ssa);
-            //}
-            //_ => panic!("Incompatible type found in the pipeline!"),
-        //}
-    //}
+//fn construct_ssa(&mut self) {
+//// TODO: Relax this condition.
+//assert!(self.state.reg_info.is_some());
+//out!("[*] Starting SSA Construction", self.verbose);
+//let pipein = self.state.pipeout.clone().unwrap();
+//let r = self.state.reg_info.clone().unwrap();
+//match pipein {
+//Pipeout::CFG {ref cfg} => {
+//let mut ssa = SSAStorage::new();
+//{
+////let mut con = SSAConstruction::new(&mut ssa, &r);
+////con.run(cfg);
+//}
+//let pipeout = Pipeout::SSA { ssa: ssa.clone() };
+//self.set_pipeout(&pipeout);
+//self.state.ssa = Some(ssa);
+//}
+//_ => panic!("Incompatible type found in the pipeline!"),
+//}
+//}
 
-    //fn analyze(&mut self, analysis: &Analysis) {
-        //out!("[*] Starting Analysis", self.verbose);
-        //let pipein = self.state.pipeout.clone().unwrap();
-        //let mut ssa = if let Pipeout::SSA { ssa } = pipein {
-            //ssa
-        //} else {
-            //panic!("Incompatible type found in the pipeline!");
-        //};
-        //let ssa = match *analysis {
-            //Analysis::ConstProp => {
-                //let mut analyzer = constant::Analyzer::new(&mut ssa);
-                //analyzer.analyze();
-                //analyzer.emit_ssa()
-            //}
-        //};
+//fn analyze(&mut self, analysis: &Analysis) {
+//out!("[*] Starting Analysis", self.verbose);
+//let pipein = self.state.pipeout.clone().unwrap();
+//let mut ssa = if let Pipeout::SSA { ssa } = pipein {
+//ssa
+//} else {
+//panic!("Incompatible type found in the pipeline!");
+//};
+//let ssa = match *analysis {
+//Analysis::ConstProp => {
+//let mut analyzer = constant::Analyzer::new(&mut ssa);
+//analyzer.analyze();
+//analyzer.emit_ssa()
+//}
+//};
 
-        //self.set_pipeout(&Pipeout::SSA { ssa: ssa.clone() });
-    //}
+//self.set_pipeout(&Pipeout::SSA { ssa: ssa.clone() });
+//}
 
-    //fn dce(&mut self) {
-        //out!("[*] Running DCE", self.verbose);
-        //let pipein = self.state.pipeout.clone().unwrap();
-        //let mut ssa = if let Pipeout::SSA { ssa } = pipein {
-            //ssa
-        //} else {
-            //panic!("Incompatible type found in the pipeline!");
-        //};
+//fn dce(&mut self) {
+//out!("[*] Running DCE", self.verbose);
+//let pipein = self.state.pipeout.clone().unwrap();
+//let mut ssa = if let Pipeout::SSA { ssa } = pipein {
+//ssa
+//} else {
+//panic!("Incompatible type found in the pipeline!");
+//};
 
-        //{
-            //dce::collect(&mut ssa);
-        //}
+//{
+//dce::collect(&mut ssa);
+//}
 
-        //self.set_pipeout(&Pipeout::SSA { ssa: ssa.clone() });
-    //}
+//self.set_pipeout(&Pipeout::SSA { ssa: ssa.clone() });
+//}
 
-    //fn verify(&mut self) {
-        //out!("[*] Verifying the Integrity of SSA.", self.verbose);
-        //let pipein = self.state.pipeout.clone().unwrap();
-        //let ssa = if let Pipeout::SSA { ssa } = pipein {
-            //ssa
-        //} else {
-            //panic!("Incompatible type found in the pipeline!");
-        //};
+//fn verify(&mut self) {
+//out!("[*] Verifying the Integrity of SSA.", self.verbose);
+//let pipein = self.state.pipeout.clone().unwrap();
+//let ssa = if let Pipeout::SSA { ssa } = pipein {
+//ssa
+//} else {
+//panic!("Incompatible type found in the pipeline!");
+//};
 
-        //{
-            //verifier::verify(&ssa).unwrap();
-        //}
-    //}
+//{
+//verifier::verify(&ssa).unwrap();
+//}
+//}
 
-    //// TODO: Return Error. Never panic!()
-    //pub fn run(&mut self) {
-        //let pipe_iter = self.pipeline.clone();
-        //for stage in pipe_iter.iter() {
-            //match *stage {
-                //Pipeline::ReadFromR2 => self.read_from_r2(),
-                //Pipeline::ParseEsil => self.parse_esil(),
-                //Pipeline::CFG => self.construct_cfg(),
-                //Pipeline::SSA => self.construct_ssa(),
-                //Pipeline::AnalyzeSSA(ref a) => self.analyze(a),
-                //Pipeline::DCE => self.dce(),
-                //Pipeline::Verify => self.verify(),
-                //Pipeline::CWriter => unimplemented!(),
-            //}
-            //self.results.push(self.state.pipeout.clone().unwrap());
-        //}
-    //}
+//// TODO: Return Error. Never panic!()
+//pub fn run(&mut self) {
+//let pipe_iter = self.pipeline.clone();
+//for stage in pipe_iter.iter() {
+//match *stage {
+//Pipeline::ReadFromR2 => self.read_from_r2(),
+//Pipeline::ParseEsil => self.parse_esil(),
+//Pipeline::CFG => self.construct_cfg(),
+//Pipeline::SSA => self.construct_ssa(),
+//Pipeline::AnalyzeSSA(ref a) => self.analyze(a),
+//Pipeline::DCE => self.dce(),
+//Pipeline::Verify => self.verify(),
+//Pipeline::CWriter => unimplemented!(),
+//}
+//self.results.push(self.state.pipeout.clone().unwrap());
+//}
+//}
 
-    //fn write_file(&self, fname: PathBuf, res: String) {
-        //let mut file = File::create(fname).ok().expect("Error. Cannot create file!\n");
-        //file.write_all(res.as_bytes()).ok().expect("Error. Cannot write file!\n");
-    //}
+//fn write_file(&self, fname: PathBuf, res: String) {
+//let mut file = File::create(fname).ok().expect("Error. Cannot create file!\n");
+//file.write_all(res.as_bytes()).ok().expect("Error. Cannot write file!\n");
+//}
 
-    //pub fn output(&self, phases: Option<Vec<u16>>) {
-        //let mut phase_num = 0;
-        //let count = self.pipeline.len() - 1;
-        //let phases = phases.unwrap_or((0..count as u16).collect::<Vec<_>>());
-        //for res in self.results.iter() {
+//pub fn output(&self, phases: Option<Vec<u16>>) {
+//let mut phase_num = 0;
+//let count = self.pipeline.len() - 1;
+//let phases = phases.unwrap_or((0..count as u16).collect::<Vec<_>>());
+//for res in self.results.iter() {
 
-            //if !phases.contains(&phase_num) {
-                //phase_num += 1;
-                //continue;
-            //}
-            //let mut write_out = String::new();
-            //let ext;
-            //match *res {
-                //Pipeout::Esil(ref s) => {
-                    //ext = "esil";
-                    //for esil in s {
-                        //let tmp = format!("{}\n", esil);
-                        //write_out.push_str(&*tmp);
-                    //}
-                //}
-                //Pipeout::LOpInfo(ref ops) => {
-                    //ext = "esil";
-                    //for op in ops {
-                        //let tmp = format!("{}:\t{}\n",
-                                          //op.offset.unwrap(),
-                                          //op.esil.clone().unwrap());
-                        //write_out.push_str(&*tmp);
-                    //}
-                //}
-                //Pipeout::Instructions {i: ref insts} => {
-                    //ext = "insts";
-                    //for inst in insts {
-                        //let tmp = format!("0x{:08X}:\t{}\n", inst.addr.val, inst);
-                        //write_out.push_str(&*tmp);
-                    //}
-                //}
-                //Pipeout::CFG {ref cfg} => {
-                    //ext = "dot";
-                    //let tmp = dot::emit_dot(cfg);
-                    //write_out.push_str(&*tmp);
-                //}
-                //Pipeout::SSA {ref ssa} => {
-                    //ext = "dot";
-                    //let tmp = dot::emit_dot(ssa);
-                    //write_out.push_str(&*tmp);
-                //}
-            //}
+//if !phases.contains(&phase_num) {
+//phase_num += 1;
+//continue;
+//}
+//let mut write_out = String::new();
+//let ext;
+//match *res {
+//Pipeout::Esil(ref s) => {
+//ext = "esil";
+//for esil in s {
+//let tmp = format!("{}\n", esil);
+//write_out.push_str(&*tmp);
+//}
+//}
+//Pipeout::LOpInfo(ref ops) => {
+//ext = "esil";
+//for op in ops {
+//let tmp = format!("{}:\t{}\n",
+//op.offset.unwrap(),
+//op.esil.clone().unwrap());
+//write_out.push_str(&*tmp);
+//}
+//}
+//Pipeout::Instructions {i: ref insts} => {
+//ext = "insts";
+//for inst in insts {
+//let tmp = format!("0x{:08X}:\t{}\n", inst.addr.val, inst);
+//write_out.push_str(&*tmp);
+//}
+//}
+//Pipeout::CFG {ref cfg} => {
+//ext = "dot";
+//let tmp = dot::emit_dot(cfg);
+//write_out.push_str(&*tmp);
+//}
+//Pipeout::SSA {ref ssa} => {
+//ext = "dot";
+//let tmp = dot::emit_dot(ssa);
+//write_out.push_str(&*tmp);
+//}
+//}
 
-            //// Format of output file name:
-            //// test_name-type-phase_num.ext
-            //let mut p = PathBuf::from(&self.outpath);
-            //p.push(self.name.clone());
-            //let pstr = format!("{}-res_{}-phase{}.{}",
-                               //self.name,
-                               //res.to_string(),
-                               //phase_num.to_string(),
-                               //ext);
-            //fs::create_dir_all(&p).ok();
-            //p.push(pstr);
-            //self.write_file(p, write_out);
-            //phase_num += 1;
-        //}
-    //}
+//// Format of output file name:
+//// test_name-type-phase_num.ext
+//let mut p = PathBuf::from(&self.outpath);
+//p.push(self.name.clone());
+//let pstr = format!("{}-res_{}-phase{}.{}",
+//self.name,
+//res.to_string(),
+//phase_num.to_string(),
+//ext);
+//fs::create_dir_all(&p).ok();
+//p.push(pstr);
+//self.write_file(p, write_out);
+//phase_num += 1;
+//}
+//}
 //}


### PR DESCRIPTION
Unfortunately, patterns are imported at *compile time*, because It seems that `cargo` doesn't allow to install extra assets.

More info regarding this issue: 
* https://stackoverflow.com/questions/39888534/how-do-i-access-assets-included-in-a-rust-cargo-project-installed-via-cargo-ins
* https://github.com/rust-lang/cargo/issues/2729

I added also a rustfmt check during the CI build to ensure no code-formatting regressions.